### PR TITLE
fix!: Use commitment when waiting for signature status

### DIFF
--- a/packages/solana/lib/src/rpc_client/rpc_client_extensions.dart
+++ b/packages/solana/lib/src/rpc_client/rpc_client_extensions.dart
@@ -42,7 +42,8 @@ extension Convenience on RPCClient {
     Future<void> check() async {
       if (clock.elapsed > timeout) {
         completer.completeError(
-          'timed out waiting for the requested status $desiredStatus',
+          TimeoutException(
+              'timed out waiting for the requested status $desiredStatus'),
         );
         return;
       }

--- a/packages/solana/test/spl_token_test.dart
+++ b/packages/solana/test/spl_token_test.dart
@@ -26,7 +26,7 @@ void main() {
         decimals: 2,
       );
 
-      expect(token.supply, equals(0));
+      expect(token.supply, equals(BigInt.zero));
       expect(token.decimals, equals(2));
 
       newTokenMint = token.mint;
@@ -98,7 +98,7 @@ void main() {
         rpcClient: client,
       );
 
-      expect(token.supply, equals(_totalSupply));
+      expect(token.supply, equals(BigInt.from(_totalSupply)));
       expect(token.decimals, equals(2));
     });
 


### PR DESCRIPTION
NOTE: This PR incidentally deals with the fact that the supply of a token is `uint64` and dart integers are signed `int64`, which is forcing us to use `BigInt` instead.