### PR TITLE
fix: Throw TransactionException in waitForSignatureStatus

### DIFF
--- a/packages/solana/lib/solana.dart
+++ b/packages/solana/lib/solana.dart
@@ -2,6 +2,11 @@ export 'src/associated_token_account_program/associated_token_account_program.da
 export 'src/crypto/ed25519_hd_keypair.dart';
 export 'src/encoder/encoder.dart'
     show Instruction, Message, Buffer, AccountMeta;
+export 'src/exceptions/bad_state_exception.dart';
+export 'src/exceptions/http_exception.dart';
+export 'src/exceptions/json_rpc_exception.dart';
+export 'src/exceptions/no_associated_token_account_exception.dart';
+export 'src/exceptions/transaction_exception.dart';
 export 'src/memo_program/memo_program.dart';
 export 'src/rpc_client/rpc_client.dart';
 export 'src/spl_token/associated_account.dart';

--- a/packages/solana/lib/src/exceptions/transaction_exception.dart
+++ b/packages/solana/lib/src/exceptions/transaction_exception.dart
@@ -1,0 +1,8 @@
+class TransactionException implements Exception {
+  TransactionException(this.error);
+
+  final Object error;
+
+  @override
+  String toString() => error.toString();
+}

--- a/packages/solana/lib/src/rpc_client/rpc_client.dart
+++ b/packages/solana/lib/src/rpc_client/rpc_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:solana/src/crypto/ed25519_hd_keypair.dart';
 import 'package:solana/src/encoder/message.dart';
+import 'package:solana/src/exceptions/transaction_exception.dart';
 import 'package:solana/src/rpc_client/account.dart';
 import 'package:solana/src/rpc_client/balance.dart';
 import 'package:solana/src/rpc_client/blockhash.dart';

--- a/packages/solana/lib/src/rpc_client/rpc_client_extensions.dart
+++ b/packages/solana/lib/src/rpc_client/rpc_client_extensions.dart
@@ -43,7 +43,8 @@ extension Convenience on RPCClient {
       if (clock.elapsed > timeout) {
         completer.completeError(
           TimeoutException(
-              'timed out waiting for the requested status $desiredStatus'),
+            'Timed out waiting for the requested status $desiredStatus',
+          ),
         );
         return;
       }
@@ -51,7 +52,7 @@ extension Convenience on RPCClient {
       final SignatureStatus? status = statuses.isEmpty ? null : statuses.first;
       if (status != null) {
         if (status.err != null) {
-          completer.completeError(status.err!);
+          completer.completeError(TransactionException(status.err!));
         } else if (status.confirmationStatus!.index >= desiredStatus.index) {
           completer.complete();
         } else {


### PR DESCRIPTION
`waitForSignatureStatus` throws `TransactionException`  in case of error instead of arbitraty object.

Also, exported exceptions from the library to use in client code.