### PR TITLE
fix: Optional fields were required in parsed instructions

### DIFF
--- a/packages/solana/lib/src/parsed_message/parsed_instruction.dart
+++ b/packages/solana/lib/src/parsed_message/parsed_instruction.dart
@@ -6,7 +6,7 @@ part 'parsed_instruction.freezed.dart';
 part 'parsed_instruction.g.dart';
 
 /// An instruction which is part of a [ParsedMessage]
-@Freezed(unionKey: 'program', fallbackUnion: 'unsupported')
+@Freezed(unionKey: 'program', fallbackUnion: 'generic')
 class ParsedInstruction with _$ParsedInstruction {
   const factory ParsedInstruction.system({
     required String programId,
@@ -27,9 +27,9 @@ class ParsedInstruction with _$ParsedInstruction {
   }) = ParsedInstructionMemo;
 
   /// Any instruction that we are not currently supporting.
-  const factory ParsedInstruction.unsupported({
+  const factory ParsedInstruction.generic({
     String? program,
-  }) = ParsedInstructionUnsupported;
+  }) = ParsedInstructionGeneric;
 
   factory ParsedInstruction.fromJson(Map<String, dynamic> json) =>
       _$ParsedInstructionFromJson(json);

--- a/packages/solana/lib/src/parsed_message/parsed_instruction.freezed.dart
+++ b/packages/solana/lib/src/parsed_message/parsed_instruction.freezed.dart
@@ -23,7 +23,7 @@ ParsedInstruction _$ParsedInstructionFromJson(Map<String, dynamic> json) {
       return ParsedInstructionMemo.fromJson(json);
 
     default:
-      return ParsedInstructionUnsupported.fromJson(json);
+      return ParsedInstructionGeneric.fromJson(json);
   }
 }
 
@@ -52,8 +52,8 @@ class _$ParsedInstructionTearOff {
     );
   }
 
-  ParsedInstructionUnsupported unsupported({String? program}) {
-    return ParsedInstructionUnsupported(
+  ParsedInstructionGeneric generic({String? program}) {
+    return ParsedInstructionGeneric(
       program: program,
     );
   }
@@ -74,7 +74,7 @@ mixin _$ParsedInstruction {
         system,
     required TResult Function(ParsedSplTokenInstruction parsed) splToken,
     required TResult Function(@JsonKey(name: 'parsed') String? memo) memo,
-    required TResult Function(String? program) unsupported,
+    required TResult Function(String? program) generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -82,7 +82,7 @@ mixin _$ParsedInstruction {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -90,7 +90,7 @@ mixin _$ParsedInstruction {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -99,7 +99,7 @@ mixin _$ParsedInstruction {
     required TResult Function(ParsedInstructionSystem value) system,
     required TResult Function(ParsedInstructionSplToken value) splToken,
     required TResult Function(ParsedInstructionMemo value) memo,
-    required TResult Function(ParsedInstructionUnsupported value) unsupported,
+    required TResult Function(ParsedInstructionGeneric value) generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -107,7 +107,7 @@ mixin _$ParsedInstruction {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -115,7 +115,7 @@ mixin _$ParsedInstruction {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -234,7 +234,7 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
         system,
     required TResult Function(ParsedSplTokenInstruction parsed) splToken,
     required TResult Function(@JsonKey(name: 'parsed') String? memo) memo,
-    required TResult Function(String? program) unsupported,
+    required TResult Function(String? program) generic,
   }) {
     return system(programId, parsed);
   }
@@ -245,7 +245,7 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
   }) {
     return system?.call(programId, parsed);
   }
@@ -256,7 +256,7 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
     required TResult orElse(),
   }) {
     if (system != null) {
@@ -271,7 +271,7 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
     required TResult Function(ParsedInstructionSystem value) system,
     required TResult Function(ParsedInstructionSplToken value) splToken,
     required TResult Function(ParsedInstructionMemo value) memo,
-    required TResult Function(ParsedInstructionUnsupported value) unsupported,
+    required TResult Function(ParsedInstructionGeneric value) generic,
   }) {
     return system(this);
   }
@@ -282,7 +282,7 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
   }) {
     return system?.call(this);
   }
@@ -293,7 +293,7 @@ class _$ParsedInstructionSystem implements ParsedInstructionSystem {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
     required TResult orElse(),
   }) {
     if (system != null) {
@@ -407,7 +407,7 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
         system,
     required TResult Function(ParsedSplTokenInstruction parsed) splToken,
     required TResult Function(@JsonKey(name: 'parsed') String? memo) memo,
-    required TResult Function(String? program) unsupported,
+    required TResult Function(String? program) generic,
   }) {
     return splToken(parsed);
   }
@@ -418,7 +418,7 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
   }) {
     return splToken?.call(parsed);
   }
@@ -429,7 +429,7 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
     required TResult orElse(),
   }) {
     if (splToken != null) {
@@ -444,7 +444,7 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
     required TResult Function(ParsedInstructionSystem value) system,
     required TResult Function(ParsedInstructionSplToken value) splToken,
     required TResult Function(ParsedInstructionMemo value) memo,
-    required TResult Function(ParsedInstructionUnsupported value) unsupported,
+    required TResult Function(ParsedInstructionGeneric value) generic,
   }) {
     return splToken(this);
   }
@@ -455,7 +455,7 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
   }) {
     return splToken?.call(this);
   }
@@ -466,7 +466,7 @@ class _$ParsedInstructionSplToken implements ParsedInstructionSplToken {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
     required TResult orElse(),
   }) {
     if (splToken != null) {
@@ -571,7 +571,7 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
         system,
     required TResult Function(ParsedSplTokenInstruction parsed) splToken,
     required TResult Function(@JsonKey(name: 'parsed') String? memo) memo,
-    required TResult Function(String? program) unsupported,
+    required TResult Function(String? program) generic,
   }) {
     return memo(this.memo);
   }
@@ -582,7 +582,7 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
   }) {
     return memo?.call(this.memo);
   }
@@ -593,7 +593,7 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
     required TResult orElse(),
   }) {
     if (memo != null) {
@@ -608,7 +608,7 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
     required TResult Function(ParsedInstructionSystem value) system,
     required TResult Function(ParsedInstructionSplToken value) splToken,
     required TResult Function(ParsedInstructionMemo value) memo,
-    required TResult Function(ParsedInstructionUnsupported value) unsupported,
+    required TResult Function(ParsedInstructionGeneric value) generic,
   }) {
     return memo(this);
   }
@@ -619,7 +619,7 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
   }) {
     return memo?.call(this);
   }
@@ -630,7 +630,7 @@ class _$ParsedInstructionMemo implements ParsedInstructionMemo {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
     required TResult orElse(),
   }) {
     if (memo != null) {
@@ -663,32 +663,30 @@ abstract class ParsedInstructionMemo implements ParsedInstruction {
 }
 
 /// @nodoc
-abstract class $ParsedInstructionUnsupportedCopyWith<$Res> {
-  factory $ParsedInstructionUnsupportedCopyWith(
-          ParsedInstructionUnsupported value,
-          $Res Function(ParsedInstructionUnsupported) then) =
-      _$ParsedInstructionUnsupportedCopyWithImpl<$Res>;
+abstract class $ParsedInstructionGenericCopyWith<$Res> {
+  factory $ParsedInstructionGenericCopyWith(ParsedInstructionGeneric value,
+          $Res Function(ParsedInstructionGeneric) then) =
+      _$ParsedInstructionGenericCopyWithImpl<$Res>;
   $Res call({String? program});
 }
 
 /// @nodoc
-class _$ParsedInstructionUnsupportedCopyWithImpl<$Res>
+class _$ParsedInstructionGenericCopyWithImpl<$Res>
     extends _$ParsedInstructionCopyWithImpl<$Res>
-    implements $ParsedInstructionUnsupportedCopyWith<$Res> {
-  _$ParsedInstructionUnsupportedCopyWithImpl(
-      ParsedInstructionUnsupported _value,
-      $Res Function(ParsedInstructionUnsupported) _then)
-      : super(_value, (v) => _then(v as ParsedInstructionUnsupported));
+    implements $ParsedInstructionGenericCopyWith<$Res> {
+  _$ParsedInstructionGenericCopyWithImpl(ParsedInstructionGeneric _value,
+      $Res Function(ParsedInstructionGeneric) _then)
+      : super(_value, (v) => _then(v as ParsedInstructionGeneric));
 
   @override
-  ParsedInstructionUnsupported get _value =>
-      super._value as ParsedInstructionUnsupported;
+  ParsedInstructionGeneric get _value =>
+      super._value as ParsedInstructionGeneric;
 
   @override
   $Res call({
     Object? program = freezed,
   }) {
-    return _then(ParsedInstructionUnsupported(
+    return _then(ParsedInstructionGeneric(
       program: program == freezed
           ? _value.program
           : program // ignore: cast_nullable_to_non_nullable
@@ -699,24 +697,24 @@ class _$ParsedInstructionUnsupportedCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
-  const _$ParsedInstructionUnsupported({this.program});
+class _$ParsedInstructionGeneric implements ParsedInstructionGeneric {
+  const _$ParsedInstructionGeneric({this.program});
 
-  factory _$ParsedInstructionUnsupported.fromJson(Map<String, dynamic> json) =>
-      _$$ParsedInstructionUnsupportedFromJson(json);
+  factory _$ParsedInstructionGeneric.fromJson(Map<String, dynamic> json) =>
+      _$$ParsedInstructionGenericFromJson(json);
 
   @override
   final String? program;
 
   @override
   String toString() {
-    return 'ParsedInstruction.unsupported(program: $program)';
+    return 'ParsedInstruction.generic(program: $program)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is ParsedInstructionUnsupported &&
+        (other is ParsedInstructionGeneric &&
             (identical(other.program, program) ||
                 const DeepCollectionEquality().equals(other.program, program)));
   }
@@ -727,9 +725,9 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
 
   @JsonKey(ignore: true)
   @override
-  $ParsedInstructionUnsupportedCopyWith<ParsedInstructionUnsupported>
-      get copyWith => _$ParsedInstructionUnsupportedCopyWithImpl<
-          ParsedInstructionUnsupported>(this, _$identity);
+  $ParsedInstructionGenericCopyWith<ParsedInstructionGeneric> get copyWith =>
+      _$ParsedInstructionGenericCopyWithImpl<ParsedInstructionGeneric>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -738,9 +736,9 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
         system,
     required TResult Function(ParsedSplTokenInstruction parsed) splToken,
     required TResult Function(@JsonKey(name: 'parsed') String? memo) memo,
-    required TResult Function(String? program) unsupported,
+    required TResult Function(String? program) generic,
   }) {
-    return unsupported(program);
+    return generic(program);
   }
 
   @override
@@ -749,9 +747,9 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
   }) {
-    return unsupported?.call(program);
+    return generic?.call(program);
   }
 
   @override
@@ -760,11 +758,11 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
     TResult Function(String programId, ParsedSystemInstruction parsed)? system,
     TResult Function(ParsedSplTokenInstruction parsed)? splToken,
     TResult Function(@JsonKey(name: 'parsed') String? memo)? memo,
-    TResult Function(String? program)? unsupported,
+    TResult Function(String? program)? generic,
     required TResult orElse(),
   }) {
-    if (unsupported != null) {
-      return unsupported(program);
+    if (generic != null) {
+      return generic(program);
     }
     return orElse();
   }
@@ -775,9 +773,9 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
     required TResult Function(ParsedInstructionSystem value) system,
     required TResult Function(ParsedInstructionSplToken value) splToken,
     required TResult Function(ParsedInstructionMemo value) memo,
-    required TResult Function(ParsedInstructionUnsupported value) unsupported,
+    required TResult Function(ParsedInstructionGeneric value) generic,
   }) {
-    return unsupported(this);
+    return generic(this);
   }
 
   @override
@@ -786,9 +784,9 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
   }) {
-    return unsupported?.call(this);
+    return generic?.call(this);
   }
 
   @override
@@ -797,31 +795,30 @@ class _$ParsedInstructionUnsupported implements ParsedInstructionUnsupported {
     TResult Function(ParsedInstructionSystem value)? system,
     TResult Function(ParsedInstructionSplToken value)? splToken,
     TResult Function(ParsedInstructionMemo value)? memo,
-    TResult Function(ParsedInstructionUnsupported value)? unsupported,
+    TResult Function(ParsedInstructionGeneric value)? generic,
     required TResult orElse(),
   }) {
-    if (unsupported != null) {
-      return unsupported(this);
+    if (generic != null) {
+      return generic(this);
     }
     return orElse();
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedInstructionUnsupportedToJson(this)
-      ..['program'] = 'unsupported';
+    return _$$ParsedInstructionGenericToJson(this)..['program'] = 'generic';
   }
 }
 
-abstract class ParsedInstructionUnsupported implements ParsedInstruction {
-  const factory ParsedInstructionUnsupported({String? program}) =
-      _$ParsedInstructionUnsupported;
+abstract class ParsedInstructionGeneric implements ParsedInstruction {
+  const factory ParsedInstructionGeneric({String? program}) =
+      _$ParsedInstructionGeneric;
 
-  factory ParsedInstructionUnsupported.fromJson(Map<String, dynamic> json) =
-      _$ParsedInstructionUnsupported.fromJson;
+  factory ParsedInstructionGeneric.fromJson(Map<String, dynamic> json) =
+      _$ParsedInstructionGeneric.fromJson;
 
   String? get program => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $ParsedInstructionUnsupportedCopyWith<ParsedInstructionUnsupported>
-      get copyWith => throw _privateConstructorUsedError;
+  $ParsedInstructionGenericCopyWith<ParsedInstructionGeneric> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/packages/solana/lib/src/parsed_message/parsed_instruction.g.dart
+++ b/packages/solana/lib/src/parsed_message/parsed_instruction.g.dart
@@ -46,14 +46,14 @@ Map<String, dynamic> _$$ParsedInstructionMemoToJson(
       'parsed': instance.memo,
     };
 
-_$ParsedInstructionUnsupported _$$ParsedInstructionUnsupportedFromJson(
+_$ParsedInstructionGeneric _$$ParsedInstructionGenericFromJson(
         Map<String, dynamic> json) =>
-    _$ParsedInstructionUnsupported(
+    _$ParsedInstructionGeneric(
       program: json['program'] as String?,
     );
 
-Map<String, dynamic> _$$ParsedInstructionUnsupportedToJson(
-        _$ParsedInstructionUnsupported instance) =>
+Map<String, dynamic> _$$ParsedInstructionGenericToJson(
+        _$ParsedInstructionGeneric instance) =>
     <String, dynamic>{
       'program': instance.program,
     };

--- a/packages/solana/lib/src/parsed_message/parsed_spl_token_instruction.dart
+++ b/packages/solana/lib/src/parsed_message/parsed_spl_token_instruction.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:solana/src/dto/meta.dart';
 import 'package:solana/src/spl_token/token_amount.dart';
 
 part 'parsed_spl_token_instruction.freezed.dart';
@@ -7,7 +8,7 @@ part 'parsed_spl_token_instruction.g.dart';
 /// An instruction of a [spl token] program
 ///
 /// [spl token]: https://spl.solana.com/token
-@Freezed(unionKey: 'type', fallbackUnion: 'unsupported')
+@Freezed(unionKey: 'type', fallbackUnion: 'generic')
 class ParsedSplTokenInstruction with _$ParsedSplTokenInstruction {
   const factory ParsedSplTokenInstruction.transfer({
     required ParsedSplTokenTransferInformation info,
@@ -19,9 +20,9 @@ class ParsedSplTokenInstruction with _$ParsedSplTokenInstruction {
     required String type,
   }) = ParsedSplTokenTransferCheckedInstruction;
 
-  const factory ParsedSplTokenInstruction.unsupported({
+  const factory ParsedSplTokenInstruction.generic({
     required String type,
-  }) = ParsedSplTokenUnsupportedInstruction;
+  }) = ParsedSplTokenGenericInstruction;
 
   factory ParsedSplTokenInstruction.fromJson(Map<String, dynamic> json) =>
       _$ParsedSplTokenInstructionFromJson(json);
@@ -54,7 +55,8 @@ class ParsedSplTokenTransferCheckedInformation
     with _$ParsedSplTokenTransferCheckedInformation {
   const factory ParsedSplTokenTransferCheckedInformation({
     required TokenAmount tokenAmount,
-    required String authority,
+    required String? authority,
+    required String? multisigAuthority,
     required String? mint,
     required String source,
     required String destination,

--- a/packages/solana/lib/src/parsed_message/parsed_spl_token_instruction.freezed.dart
+++ b/packages/solana/lib/src/parsed_message/parsed_spl_token_instruction.freezed.dart
@@ -22,7 +22,7 @@ ParsedSplTokenInstruction _$ParsedSplTokenInstructionFromJson(
       return ParsedSplTokenTransferCheckedInstruction.fromJson(json);
 
     default:
-      return ParsedSplTokenUnsupportedInstruction.fromJson(json);
+      return ParsedSplTokenGenericInstruction.fromJson(json);
   }
 }
 
@@ -47,8 +47,8 @@ class _$ParsedSplTokenInstructionTearOff {
     );
   }
 
-  ParsedSplTokenUnsupportedInstruction unsupported({required String type}) {
-    return ParsedSplTokenUnsupportedInstruction(
+  ParsedSplTokenGenericInstruction generic({required String type}) {
+    return ParsedSplTokenGenericInstruction(
       type: type,
     );
   }
@@ -73,7 +73,7 @@ mixin _$ParsedSplTokenInstruction {
     required TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)
         transferChecked,
-    required TResult Function(String type) unsupported,
+    required TResult Function(String type) generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -83,7 +83,7 @@ mixin _$ParsedSplTokenInstruction {
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -93,7 +93,7 @@ mixin _$ParsedSplTokenInstruction {
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -102,8 +102,7 @@ mixin _$ParsedSplTokenInstruction {
     required TResult Function(ParsedSplTokenTransferInstruction value) transfer,
     required TResult Function(ParsedSplTokenTransferCheckedInstruction value)
         transferChecked,
-    required TResult Function(ParsedSplTokenUnsupportedInstruction value)
-        unsupported,
+    required TResult Function(ParsedSplTokenGenericInstruction value) generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -111,7 +110,7 @@ mixin _$ParsedSplTokenInstruction {
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -119,7 +118,7 @@ mixin _$ParsedSplTokenInstruction {
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -263,7 +262,7 @@ class _$ParsedSplTokenTransferInstruction
     required TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)
         transferChecked,
-    required TResult Function(String type) unsupported,
+    required TResult Function(String type) generic,
   }) {
     return transfer(info, type);
   }
@@ -276,7 +275,7 @@ class _$ParsedSplTokenTransferInstruction
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
   }) {
     return transfer?.call(info, type);
   }
@@ -289,7 +288,7 @@ class _$ParsedSplTokenTransferInstruction
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
     required TResult orElse(),
   }) {
     if (transfer != null) {
@@ -304,8 +303,7 @@ class _$ParsedSplTokenTransferInstruction
     required TResult Function(ParsedSplTokenTransferInstruction value) transfer,
     required TResult Function(ParsedSplTokenTransferCheckedInstruction value)
         transferChecked,
-    required TResult Function(ParsedSplTokenUnsupportedInstruction value)
-        unsupported,
+    required TResult Function(ParsedSplTokenGenericInstruction value) generic,
   }) {
     return transfer(this);
   }
@@ -316,7 +314,7 @@ class _$ParsedSplTokenTransferInstruction
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
   }) {
     return transfer?.call(this);
   }
@@ -327,7 +325,7 @@ class _$ParsedSplTokenTransferInstruction
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
     required TResult orElse(),
   }) {
     if (transfer != null) {
@@ -468,7 +466,7 @@ class _$ParsedSplTokenTransferCheckedInstruction
     required TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)
         transferChecked,
-    required TResult Function(String type) unsupported,
+    required TResult Function(String type) generic,
   }) {
     return transferChecked(info, type);
   }
@@ -481,7 +479,7 @@ class _$ParsedSplTokenTransferCheckedInstruction
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
   }) {
     return transferChecked?.call(info, type);
   }
@@ -494,7 +492,7 @@ class _$ParsedSplTokenTransferCheckedInstruction
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
     required TResult orElse(),
   }) {
     if (transferChecked != null) {
@@ -509,8 +507,7 @@ class _$ParsedSplTokenTransferCheckedInstruction
     required TResult Function(ParsedSplTokenTransferInstruction value) transfer,
     required TResult Function(ParsedSplTokenTransferCheckedInstruction value)
         transferChecked,
-    required TResult Function(ParsedSplTokenUnsupportedInstruction value)
-        unsupported,
+    required TResult Function(ParsedSplTokenGenericInstruction value) generic,
   }) {
     return transferChecked(this);
   }
@@ -521,7 +518,7 @@ class _$ParsedSplTokenTransferCheckedInstruction
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
   }) {
     return transferChecked?.call(this);
   }
@@ -532,7 +529,7 @@ class _$ParsedSplTokenTransferCheckedInstruction
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
     required TResult orElse(),
   }) {
     if (transferChecked != null) {
@@ -570,34 +567,34 @@ abstract class ParsedSplTokenTransferCheckedInstruction
 }
 
 /// @nodoc
-abstract class $ParsedSplTokenUnsupportedInstructionCopyWith<$Res>
+abstract class $ParsedSplTokenGenericInstructionCopyWith<$Res>
     implements $ParsedSplTokenInstructionCopyWith<$Res> {
-  factory $ParsedSplTokenUnsupportedInstructionCopyWith(
-          ParsedSplTokenUnsupportedInstruction value,
-          $Res Function(ParsedSplTokenUnsupportedInstruction) then) =
-      _$ParsedSplTokenUnsupportedInstructionCopyWithImpl<$Res>;
+  factory $ParsedSplTokenGenericInstructionCopyWith(
+          ParsedSplTokenGenericInstruction value,
+          $Res Function(ParsedSplTokenGenericInstruction) then) =
+      _$ParsedSplTokenGenericInstructionCopyWithImpl<$Res>;
   @override
   $Res call({String type});
 }
 
 /// @nodoc
-class _$ParsedSplTokenUnsupportedInstructionCopyWithImpl<$Res>
+class _$ParsedSplTokenGenericInstructionCopyWithImpl<$Res>
     extends _$ParsedSplTokenInstructionCopyWithImpl<$Res>
-    implements $ParsedSplTokenUnsupportedInstructionCopyWith<$Res> {
-  _$ParsedSplTokenUnsupportedInstructionCopyWithImpl(
-      ParsedSplTokenUnsupportedInstruction _value,
-      $Res Function(ParsedSplTokenUnsupportedInstruction) _then)
-      : super(_value, (v) => _then(v as ParsedSplTokenUnsupportedInstruction));
+    implements $ParsedSplTokenGenericInstructionCopyWith<$Res> {
+  _$ParsedSplTokenGenericInstructionCopyWithImpl(
+      ParsedSplTokenGenericInstruction _value,
+      $Res Function(ParsedSplTokenGenericInstruction) _then)
+      : super(_value, (v) => _then(v as ParsedSplTokenGenericInstruction));
 
   @override
-  ParsedSplTokenUnsupportedInstruction get _value =>
-      super._value as ParsedSplTokenUnsupportedInstruction;
+  ParsedSplTokenGenericInstruction get _value =>
+      super._value as ParsedSplTokenGenericInstruction;
 
   @override
   $Res call({
     Object? type = freezed,
   }) {
-    return _then(ParsedSplTokenUnsupportedInstruction(
+    return _then(ParsedSplTokenGenericInstruction(
       type: type == freezed
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -608,26 +605,26 @@ class _$ParsedSplTokenUnsupportedInstructionCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ParsedSplTokenUnsupportedInstruction
-    implements ParsedSplTokenUnsupportedInstruction {
-  const _$ParsedSplTokenUnsupportedInstruction({required this.type});
+class _$ParsedSplTokenGenericInstruction
+    implements ParsedSplTokenGenericInstruction {
+  const _$ParsedSplTokenGenericInstruction({required this.type});
 
-  factory _$ParsedSplTokenUnsupportedInstruction.fromJson(
+  factory _$ParsedSplTokenGenericInstruction.fromJson(
           Map<String, dynamic> json) =>
-      _$$ParsedSplTokenUnsupportedInstructionFromJson(json);
+      _$$ParsedSplTokenGenericInstructionFromJson(json);
 
   @override
   final String type;
 
   @override
   String toString() {
-    return 'ParsedSplTokenInstruction.unsupported(type: $type)';
+    return 'ParsedSplTokenInstruction.generic(type: $type)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is ParsedSplTokenUnsupportedInstruction &&
+        (other is ParsedSplTokenGenericInstruction &&
             (identical(other.type, type) ||
                 const DeepCollectionEquality().equals(other.type, type)));
   }
@@ -638,10 +635,9 @@ class _$ParsedSplTokenUnsupportedInstruction
 
   @JsonKey(ignore: true)
   @override
-  $ParsedSplTokenUnsupportedInstructionCopyWith<
-          ParsedSplTokenUnsupportedInstruction>
-      get copyWith => _$ParsedSplTokenUnsupportedInstructionCopyWithImpl<
-          ParsedSplTokenUnsupportedInstruction>(this, _$identity);
+  $ParsedSplTokenGenericInstructionCopyWith<ParsedSplTokenGenericInstruction>
+      get copyWith => _$ParsedSplTokenGenericInstructionCopyWithImpl<
+          ParsedSplTokenGenericInstruction>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -652,9 +648,9 @@ class _$ParsedSplTokenUnsupportedInstruction
     required TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)
         transferChecked,
-    required TResult Function(String type) unsupported,
+    required TResult Function(String type) generic,
   }) {
-    return unsupported(type);
+    return generic(type);
   }
 
   @override
@@ -665,9 +661,9 @@ class _$ParsedSplTokenUnsupportedInstruction
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
   }) {
-    return unsupported?.call(type);
+    return generic?.call(type);
   }
 
   @override
@@ -678,11 +674,11 @@ class _$ParsedSplTokenUnsupportedInstruction
     TResult Function(
             ParsedSplTokenTransferCheckedInformation info, String type)?
         transferChecked,
-    TResult Function(String type)? unsupported,
+    TResult Function(String type)? generic,
     required TResult orElse(),
   }) {
-    if (unsupported != null) {
-      return unsupported(type);
+    if (generic != null) {
+      return generic(type);
     }
     return orElse();
   }
@@ -693,10 +689,9 @@ class _$ParsedSplTokenUnsupportedInstruction
     required TResult Function(ParsedSplTokenTransferInstruction value) transfer,
     required TResult Function(ParsedSplTokenTransferCheckedInstruction value)
         transferChecked,
-    required TResult Function(ParsedSplTokenUnsupportedInstruction value)
-        unsupported,
+    required TResult Function(ParsedSplTokenGenericInstruction value) generic,
   }) {
-    return unsupported(this);
+    return generic(this);
   }
 
   @override
@@ -705,9 +700,9 @@ class _$ParsedSplTokenUnsupportedInstruction
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
   }) {
-    return unsupported?.call(this);
+    return generic?.call(this);
   }
 
   @override
@@ -716,37 +711,35 @@ class _$ParsedSplTokenUnsupportedInstruction
     TResult Function(ParsedSplTokenTransferInstruction value)? transfer,
     TResult Function(ParsedSplTokenTransferCheckedInstruction value)?
         transferChecked,
-    TResult Function(ParsedSplTokenUnsupportedInstruction value)? unsupported,
+    TResult Function(ParsedSplTokenGenericInstruction value)? generic,
     required TResult orElse(),
   }) {
-    if (unsupported != null) {
-      return unsupported(this);
+    if (generic != null) {
+      return generic(this);
     }
     return orElse();
   }
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ParsedSplTokenUnsupportedInstructionToJson(this)
-      ..['type'] = 'unsupported';
+    return _$$ParsedSplTokenGenericInstructionToJson(this)
+      ..['type'] = 'generic';
   }
 }
 
-abstract class ParsedSplTokenUnsupportedInstruction
+abstract class ParsedSplTokenGenericInstruction
     implements ParsedSplTokenInstruction {
-  const factory ParsedSplTokenUnsupportedInstruction({required String type}) =
-      _$ParsedSplTokenUnsupportedInstruction;
+  const factory ParsedSplTokenGenericInstruction({required String type}) =
+      _$ParsedSplTokenGenericInstruction;
 
-  factory ParsedSplTokenUnsupportedInstruction.fromJson(
-          Map<String, dynamic> json) =
-      _$ParsedSplTokenUnsupportedInstruction.fromJson;
+  factory ParsedSplTokenGenericInstruction.fromJson(Map<String, dynamic> json) =
+      _$ParsedSplTokenGenericInstruction.fromJson;
 
   @override
   String get type => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
-  $ParsedSplTokenUnsupportedInstructionCopyWith<
-          ParsedSplTokenUnsupportedInstruction>
+  $ParsedSplTokenGenericInstructionCopyWith<ParsedSplTokenGenericInstruction>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1028,13 +1021,15 @@ class _$ParsedSplTokenTransferCheckedInformationTearOff {
 
   _ParsedSplTokenTransferCheckedInformation call(
       {required TokenAmount tokenAmount,
-      required String authority,
+      required String? authority,
+      required String? multisigAuthority,
       required String? mint,
       required String source,
       required String destination}) {
     return _ParsedSplTokenTransferCheckedInformation(
       tokenAmount: tokenAmount,
       authority: authority,
+      multisigAuthority: multisigAuthority,
       mint: mint,
       source: source,
       destination: destination,
@@ -1053,7 +1048,8 @@ const $ParsedSplTokenTransferCheckedInformation =
 /// @nodoc
 mixin _$ParsedSplTokenTransferCheckedInformation {
   TokenAmount get tokenAmount => throw _privateConstructorUsedError;
-  String get authority => throw _privateConstructorUsedError;
+  String? get authority => throw _privateConstructorUsedError;
+  String? get multisigAuthority => throw _privateConstructorUsedError;
   String? get mint => throw _privateConstructorUsedError;
   String get source => throw _privateConstructorUsedError;
   String get destination => throw _privateConstructorUsedError;
@@ -1073,7 +1069,8 @@ abstract class $ParsedSplTokenTransferCheckedInformationCopyWith<$Res> {
       _$ParsedSplTokenTransferCheckedInformationCopyWithImpl<$Res>;
   $Res call(
       {TokenAmount tokenAmount,
-      String authority,
+      String? authority,
+      String? multisigAuthority,
       String? mint,
       String source,
       String destination});
@@ -1093,6 +1090,7 @@ class _$ParsedSplTokenTransferCheckedInformationCopyWithImpl<$Res>
   $Res call({
     Object? tokenAmount = freezed,
     Object? authority = freezed,
+    Object? multisigAuthority = freezed,
     Object? mint = freezed,
     Object? source = freezed,
     Object? destination = freezed,
@@ -1105,7 +1103,11 @@ class _$ParsedSplTokenTransferCheckedInformationCopyWithImpl<$Res>
       authority: authority == freezed
           ? _value.authority
           : authority // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
+      multisigAuthority: multisigAuthority == freezed
+          ? _value.multisigAuthority
+          : multisigAuthority // ignore: cast_nullable_to_non_nullable
+              as String?,
       mint: mint == freezed
           ? _value.mint
           : mint // ignore: cast_nullable_to_non_nullable
@@ -1132,7 +1134,8 @@ abstract class _$ParsedSplTokenTransferCheckedInformationCopyWith<$Res>
   @override
   $Res call(
       {TokenAmount tokenAmount,
-      String authority,
+      String? authority,
+      String? multisigAuthority,
       String? mint,
       String source,
       String destination});
@@ -1156,6 +1159,7 @@ class __$ParsedSplTokenTransferCheckedInformationCopyWithImpl<$Res>
   $Res call({
     Object? tokenAmount = freezed,
     Object? authority = freezed,
+    Object? multisigAuthority = freezed,
     Object? mint = freezed,
     Object? source = freezed,
     Object? destination = freezed,
@@ -1168,7 +1172,11 @@ class __$ParsedSplTokenTransferCheckedInformationCopyWithImpl<$Res>
       authority: authority == freezed
           ? _value.authority
           : authority // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
+      multisigAuthority: multisigAuthority == freezed
+          ? _value.multisigAuthority
+          : multisigAuthority // ignore: cast_nullable_to_non_nullable
+              as String?,
       mint: mint == freezed
           ? _value.mint
           : mint // ignore: cast_nullable_to_non_nullable
@@ -1192,6 +1200,7 @@ class _$_ParsedSplTokenTransferCheckedInformation
   const _$_ParsedSplTokenTransferCheckedInformation(
       {required this.tokenAmount,
       required this.authority,
+      required this.multisigAuthority,
       required this.mint,
       required this.source,
       required this.destination});
@@ -1203,7 +1212,9 @@ class _$_ParsedSplTokenTransferCheckedInformation
   @override
   final TokenAmount tokenAmount;
   @override
-  final String authority;
+  final String? authority;
+  @override
+  final String? multisigAuthority;
   @override
   final String? mint;
   @override
@@ -1213,7 +1224,7 @@ class _$_ParsedSplTokenTransferCheckedInformation
 
   @override
   String toString() {
-    return 'ParsedSplTokenTransferCheckedInformation(tokenAmount: $tokenAmount, authority: $authority, mint: $mint, source: $source, destination: $destination)';
+    return 'ParsedSplTokenTransferCheckedInformation(tokenAmount: $tokenAmount, authority: $authority, multisigAuthority: $multisigAuthority, mint: $mint, source: $source, destination: $destination)';
   }
 
   @override
@@ -1226,6 +1237,9 @@ class _$_ParsedSplTokenTransferCheckedInformation
             (identical(other.authority, authority) ||
                 const DeepCollectionEquality()
                     .equals(other.authority, authority)) &&
+            (identical(other.multisigAuthority, multisigAuthority) ||
+                const DeepCollectionEquality()
+                    .equals(other.multisigAuthority, multisigAuthority)) &&
             (identical(other.mint, mint) ||
                 const DeepCollectionEquality().equals(other.mint, mint)) &&
             (identical(other.source, source) ||
@@ -1240,6 +1254,7 @@ class _$_ParsedSplTokenTransferCheckedInformation
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(tokenAmount) ^
       const DeepCollectionEquality().hash(authority) ^
+      const DeepCollectionEquality().hash(multisigAuthority) ^
       const DeepCollectionEquality().hash(mint) ^
       const DeepCollectionEquality().hash(source) ^
       const DeepCollectionEquality().hash(destination);
@@ -1261,7 +1276,8 @@ abstract class _ParsedSplTokenTransferCheckedInformation
     implements ParsedSplTokenTransferCheckedInformation {
   const factory _ParsedSplTokenTransferCheckedInformation(
           {required TokenAmount tokenAmount,
-          required String authority,
+          required String? authority,
+          required String? multisigAuthority,
           required String? mint,
           required String source,
           required String destination}) =
@@ -1274,7 +1290,9 @@ abstract class _ParsedSplTokenTransferCheckedInformation
   @override
   TokenAmount get tokenAmount => throw _privateConstructorUsedError;
   @override
-  String get authority => throw _privateConstructorUsedError;
+  String? get authority => throw _privateConstructorUsedError;
+  @override
+  String? get multisigAuthority => throw _privateConstructorUsedError;
   @override
   String? get mint => throw _privateConstructorUsedError;
   @override

--- a/packages/solana/lib/src/parsed_message/parsed_spl_token_instruction.g.dart
+++ b/packages/solana/lib/src/parsed_message/parsed_spl_token_instruction.g.dart
@@ -37,15 +37,14 @@ Map<String, dynamic> _$$ParsedSplTokenTransferCheckedInstructionToJson(
       'type': instance.type,
     };
 
-_$ParsedSplTokenUnsupportedInstruction
-    _$$ParsedSplTokenUnsupportedInstructionFromJson(
-            Map<String, dynamic> json) =>
-        _$ParsedSplTokenUnsupportedInstruction(
-          type: json['type'] as String,
-        );
+_$ParsedSplTokenGenericInstruction _$$ParsedSplTokenGenericInstructionFromJson(
+        Map<String, dynamic> json) =>
+    _$ParsedSplTokenGenericInstruction(
+      type: json['type'] as String,
+    );
 
-Map<String, dynamic> _$$ParsedSplTokenUnsupportedInstructionToJson(
-        _$ParsedSplTokenUnsupportedInstruction instance) =>
+Map<String, dynamic> _$$ParsedSplTokenGenericInstructionToJson(
+        _$ParsedSplTokenGenericInstruction instance) =>
     <String, dynamic>{
       'type': instance.type,
     };
@@ -76,7 +75,8 @@ _$_ParsedSplTokenTransferCheckedInformation
         _$_ParsedSplTokenTransferCheckedInformation(
           tokenAmount:
               TokenAmount.fromJson(json['tokenAmount'] as Map<String, dynamic>),
-          authority: json['authority'] as String,
+          authority: json['authority'] as String?,
+          multisigAuthority: json['multisigAuthority'] as String?,
           mint: json['mint'] as String?,
           source: json['source'] as String,
           destination: json['destination'] as String,
@@ -87,6 +87,7 @@ Map<String, dynamic> _$$_ParsedSplTokenTransferCheckedInformationToJson(
     <String, dynamic>{
       'tokenAmount': instance.tokenAmount,
       'authority': instance.authority,
+      'multisigAuthority': instance.multisigAuthority,
       'mint': instance.mint,
       'source': instance.source,
       'destination': instance.destination,


### PR DESCRIPTION
- Make some fields optional in parsed trasfer checked for spl token instruction and add one more missing field.
- Rename unsupported to generic as to indicate that we are supporting them but not paying any special attention to their content.