### PR TITLE
Add middlewares to JsonRpcClient

### DIFF
--- a/packages/jsonrpc_client/lib/src/client_generator.dart
+++ b/packages/jsonrpc_client/lib/src/client_generator.dart
@@ -20,6 +20,8 @@ class ClientGenerator extends GeneratorForAnnotation<SolanaRpcClient> {
 class _${element.name} implements ${element.name} {
   _${element.name}(String url) : _client = JsonRpcClient(url);
   
+  _${element.name}.forClient(this._client);
+  
   final JsonRpcClient _client;
   
   ${methods.map(_generateMethod).join('\n')}

--- a/packages/solana/lib/src/rpc/client.dart
+++ b/packages/solana/lib/src/rpc/client.dart
@@ -17,6 +17,8 @@ part 'extension.dart';
 abstract class RpcClient {
   factory RpcClient(String url) => _RpcClient(url);
 
+  factory RpcClient.forClient(JsonRpcClient client) => _RpcClient.forClient(client);
+
   /// Returns all information associated with the account of provided Pubkey
   ///
   /// [pubKey] Pubkey of account to query, as base-58 encoded string

--- a/packages/solana/lib/src/rpc/client.rpc.dart
+++ b/packages/solana/lib/src/rpc/client.rpc.dart
@@ -9,6 +9,8 @@ part of 'client.dart';
 class _RpcClient implements RpcClient {
   _RpcClient(String url) : _client = JsonRpcClient(url);
 
+  _RpcClient.forClient(this._client);
+
   final JsonRpcClient _client;
 
   @override


### PR DESCRIPTION
Add middlewares to JsonRpcClient

We need to add our own rate limit manager to the client, and this is the least intrusive way to do it.
So we need at least a "onBeforeSend" method