### PR TITLE
Use web_socket_channel package instead of dart:io for sockets

### DIFF
--- a/packages/solana/pubspec.yaml
+++ b/packages/solana/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   freezed_annotation: ^0.14.2
   http: ^0.13.3
   json_annotation: ^4.0.1
+  web_socket_channel: 2.1.0
 
 dev_dependencies:
   borsh: ^0.2.0+1


### PR DESCRIPTION
dart:io can't be used on web. We are testing exclusively on web so we have an error ;)
We fixed it by using the [web_socket_channel  package](https://pub.dev/packages/web_socket_channel)