### PR TITLE
refactor!: Update Wallet

### DIFF
--- a/packages/solana/lib/src/programs/token_program/token_program.dart
+++ b/packages/solana/lib/src/programs/token_program/token_program.dart
@@ -1,5 +1,6 @@
 import 'package:solana/src/encoder/instruction.dart';
 import 'package:solana/src/encoder/message.dart';
+import 'package:solana/src/programs/memo_program/memo_instruction.dart';
 import 'package:solana/src/programs/system_program/system_program.dart';
 import 'package:solana/src/programs/token_program/token_instruction.dart';
 
@@ -117,6 +118,7 @@ class TokenProgram extends Message {
     required String destination,
     required String owner,
     required int amount,
+    String? memo,
   }) =>
       TokenProgram._(
         instructions: [
@@ -125,7 +127,8 @@ class TokenProgram extends Message {
             destination: destination,
             owner: owner,
             amount: amount,
-          )
+          ),
+          if (memo != null) MemoInstruction(signers: [owner], memo: memo),
         ],
       );
 

--- a/packages/solana/test/rpc_client_test.dart
+++ b/packages/solana/test/rpc_client_test.dart
@@ -233,11 +233,14 @@ void main() {
         owner: wallet,
         subscriptionClient: subscriptionClient,
         decimals: 8,
+        rpcClient: rpcClient,
       );
 
       final createdAccount = await token.createAssociatedAccount(
         owner: accountKeyPair.address,
         funder: accountCreator,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
       expect(createdAccount, isNotNull);
 
@@ -818,6 +821,7 @@ Future<SplToken> _createToken({
     decimals: 2,
     owner: tokenMintAuthority,
     subscriptionClient: subscriptionClient,
+    rpcClient: rpcClient,
   );
   // Now lets create an account to store the supply. All SPL token transfer
   // must be done to an associated token account which belongs to the specific
@@ -827,19 +831,30 @@ Future<SplToken> _createToken({
   final supplyAccount = await splToken.createAssociatedAccount(
     owner: tokenMintAuthority.address,
     funder: tokenMintAuthority,
+    rpcClient: rpcClient,
+    subscriptionClient: subscriptionClient,
   );
   // Now we have a spl token, let's add the supply to it
   await splToken.mintTo(
     destination: supplyAccount.pubkey,
     amount: supply,
+    rpcClient: rpcClient,
+    subscriptionClient: subscriptionClient,
   );
 
   // We must check if the recipient has an associated token account, if not
   // we have to create it
-  if (await splToken.getAssociatedAccount(transferSomeToAddress) == null) {
+
+  final associatedAccount = await splToken.getAssociatedAccount(
+    transferSomeToAddress,
+    rpcClient: rpcClient,
+  );
+  if (associatedAccount == null) {
     await splToken.createAssociatedAccount(
       owner: transferSomeToAddress,
       funder: tokenMintAuthority,
+      rpcClient: rpcClient,
+      subscriptionClient: subscriptionClient,
     );
   }
 
@@ -850,6 +865,8 @@ Future<SplToken> _createToken({
     destination: transferSomeToAddress,
     amount: transferSomeToAmount,
     owner: tokenMintAuthority,
+    rpcClient: rpcClient,
+    subscriptionClient: subscriptionClient,
   );
 
   return splToken;

--- a/packages/solana/test/spl_token_test.dart
+++ b/packages/solana/test/spl_token_test.dart
@@ -37,6 +37,7 @@ void main() {
         owner: owner,
         subscriptionClient: subscriptionClient,
         decimals: 2,
+        rpcClient: rpcClient,
       );
 
       expect(token.supply, equals(BigInt.zero));
@@ -52,11 +53,12 @@ void main() {
       final token = await SplToken.readonly(
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       await token.createAccount(
         account: account,
         creator: creator,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
     }, timeout: const Timeout(Duration(minutes: 2)));
 
@@ -65,7 +67,6 @@ void main() {
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       List<ProgramAccount> accounts = await rpcClient.getTokenAccountsByOwner(
         owner.address,
@@ -77,6 +78,8 @@ void main() {
       final newAccount = await token.createAssociatedAccount(
         owner: owner.address,
         funder: owner,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
 
       accounts = await rpcClient.getTokenAccountsByOwner(
@@ -97,7 +100,6 @@ void main() {
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       final accounts = await rpcClient.getTokenAccountsByOwner(
         owner.address,
@@ -107,13 +109,14 @@ void main() {
       await token.mintTo(
         destination: accounts.first.pubkey,
         amount: _totalSupply,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
       // Reload it
       token = await SplToken.readWrite(
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
 
       expect(token.supply, equals(BigInt.from(_totalSupply)));
@@ -134,12 +137,13 @@ void main() {
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       // The account does not exist, so create it
       final account = await token.createAssociatedAccount(
         owner: recipient.address,
         funder: owner,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
       expect(account, isA<ProgramAccount>());
       // Send to the newly created account
@@ -148,6 +152,8 @@ void main() {
         destination: recipient.address,
         amount: 100,
         owner: owner,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
 
       expect(signature, isNot(null));
@@ -159,7 +165,6 @@ void main() {
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       final feePayer = await Ed25519HDKeyPair.random();
       // Add some tokens to pay for fees
@@ -169,14 +174,21 @@ void main() {
       final account = await token.createAssociatedAccount(
         owner: recipient.address,
         funder: owner,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
       // A sender must have the appropriate associated account, in case they
       // don't it's an error and we should throw an exception.
-      final sourceAssociatedTokenAddress =
-          await token.getAssociatedAccount(owner.address);
+      final sourceAssociatedTokenAddress = await token.getAssociatedAccount(
+        owner.address,
+        rpcClient: rpcClient,
+      );
       // A recipient needs an associated account as well
       final destinationAssociatedTokenAddress =
-          await token.getAssociatedAccount(recipient.address);
+          await token.getAssociatedAccount(
+        recipient.address,
+        rpcClient: rpcClient,
+      );
       expect(sourceAssociatedTokenAddress, isNotNull);
       expect(destinationAssociatedTokenAddress, isNotNull);
 
@@ -212,7 +224,6 @@ void main() {
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       // Send to the newly created account
       expect(
@@ -221,6 +232,8 @@ void main() {
           destination: recipient.address,
           amount: 100,
           owner: owner,
+          rpcClient: rpcClient,
+          subscriptionClient: subscriptionClient,
         ),
         throwsA(isA<NoAssociatedTokenAccountException>()),
       );
@@ -234,7 +247,6 @@ void main() {
         owner: owner,
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       // Send to the newly created account
       expect(
@@ -243,6 +255,8 @@ void main() {
           destination: owner.address,
           amount: 100,
           owner: owner,
+          rpcClient: rpcClient,
+          subscriptionClient: subscriptionClient,
         ),
         throwsA(isA<NoAssociatedTokenAccountException>()),
       );
@@ -253,13 +267,14 @@ void main() {
       final token = await SplToken.readonly(
         mint: newTokenMint,
         rpcClient: rpcClient,
-        subscriptionClient: subscriptionClient,
       );
       final associatedSourceAddress =
           await token.computeAssociatedAddress(owner: owner.address);
       final destinationAccount = await token.createAccount(
         account: destination,
         creator: owner,
+        rpcClient: rpcClient,
+        subscriptionClient: subscriptionClient,
       );
 
       final instructions = <Instruction>[

--- a/packages/solana/test/subscription_client_test.dart
+++ b/packages/solana/test/subscription_client_test.dart
@@ -31,15 +31,12 @@ void main() {
     final accountStream = subscriptionClient.accountSubscribe(sender.address);
 
     // Now send some tokens
-    final wallet = Wallet(
-      sender,
-      rpcClient: rpcClient,
-      subscriptionClient: subscriptionClient,
-    );
-    await wallet.transfer(
+    await sender.transfer(
       destination: recipient.address,
       commitment: Commitment.confirmed,
       lamports: lamportsPerSol ~/ 2,
+      rpcClient: rpcClient,
+      subscriptionClient: subscriptionClient,
     );
 
     final account = await accountStream.firstWhere(


### PR DESCRIPTION
- `Wallet` is now an alias of `Ed25519HDKeyPair` (as a more semantical name).
- `RpcClient` and `SubscriptionClient` are no longer part of `SplToken`, they are passed as arguments to the methods that need them.
- `memo` is now an optional argument of `transfer*` methods (instead of separate methods).