### PR TITLE
refactor: Extract snackbars to cryptoplease_ui

### DIFF
--- a/packages/cryptoplease/lib/presentation/screens/authenticated/nft/nft_screen.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/nft/nft_screen.dart
@@ -3,7 +3,6 @@ import 'package:cryptoplease/bl/tokens/token.dart';
 import 'package:cryptoplease/l10n/l10n.dart';
 import 'package:cryptoplease/presentation/components/empty_widget.dart';
 import 'package:cryptoplease/presentation/screens/authenticated/nft/nft_item.dart';
-import 'package:cryptoplease/presentation/snackbars.dart';
 import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
@@ -41,7 +40,7 @@ class _NftScreenState extends State<NftScreen> {
   Widget build(BuildContext context) =>
       BlocConsumer<NftCollectionBloc, NftCollectionState>(
         listener: (context, state) => state.processingState.maybeWhen(
-          error: (_) => showErrorSnackbar(
+          error: (_) => showCpErrorSnackbar(
             context,
             message: context.l10n.errorLoadingPullToRefresh,
           ),

--- a/packages/cryptoplease/lib/presentation/screens/authenticated/wallet_screen.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/wallet_screen.dart
@@ -12,7 +12,6 @@ import 'package:cryptoplease/presentation/screens/authenticated/components/heade
 import 'package:cryptoplease/presentation/screens/authenticated/components/stablecoin_empty_widget.dart';
 import 'package:cryptoplease/presentation/screens/authenticated/components/total_balance_widget.dart';
 import 'package:cryptoplease/presentation/screens/authenticated/components/wallet_tab_bar.dart';
-import 'package:cryptoplease/presentation/snackbars.dart';
 import 'package:cryptoplease/presentation/watch_balance.dart';
 import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:dfunc/dfunc.dart';
@@ -144,18 +143,15 @@ class _WalletScreenState extends State<WalletScreen> {
       );
 }
 
-void _showFetchBalancesErrorToast(BuildContext context) {
-  showCustomSnackbar(
-    context,
-    message: context.l10n.cannotConnectToTheNetwork,
-    icon: Assets.icons.toastWarning.image(),
-  );
-}
+void _showFetchBalancesErrorToast(BuildContext context) => showCpSnackbar(
+      context,
+      message: context.l10n.cannotConnectToTheNetwork,
+      icon: Assets.icons.toastWarning.image(),
+    );
 
-void _showConversionRatesFetchErrorToast(BuildContext context) {
-  showCustomSnackbar(
-    context,
-    message: context.l10n.weWereUnableToFetchTokenPrice,
-    icon: Assets.icons.toastWarning.image(),
-  );
-}
+void _showConversionRatesFetchErrorToast(BuildContext context) =>
+    showCpSnackbar(
+      context,
+      message: context.l10n.weWereUnableToFetchTokenPrice,
+      icon: Assets.icons.toastWarning.image(),
+    );

--- a/packages/cryptoplease/lib/presentation/snackbars.dart
+++ b/packages/cryptoplease/lib/presentation/snackbars.dart
@@ -1,48 +1,9 @@
 import 'package:cryptoplease/l10n/l10n.dart';
+import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:flutter/material.dart';
 
-void showClipboardSnackbar(BuildContext context) => showCustomSnackbar(
+void showClipboardSnackbar(BuildContext context) => showCpSnackbar(
       context,
       message: context.l10n.copiedToClipboard,
       icon: const Icon(Icons.check, color: Colors.green),
     );
-
-void showErrorSnackbar(BuildContext context, {required String message}) =>
-    showCustomSnackbar(
-      context,
-      message: message,
-      icon: const Icon(Icons.error, color: Colors.red),
-    );
-
-void showCustomSnackbar(
-  BuildContext context, {
-  required String message,
-  Widget? icon,
-}) {
-  final snackbar = SnackBar(
-    behavior: SnackBarBehavior.floating,
-    shape: const StadiumBorder(),
-    content: ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 24),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          if (icon != null)
-            Container(
-              height: 24,
-              margin: const EdgeInsets.only(right: 16),
-              child: icon,
-            ),
-          Expanded(
-            child: Text(
-              message,
-              style: const TextStyle(color: Colors.white),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-
-  ScaffoldMessenger.of(context).showSnackBar(snackbar);
-}

--- a/packages/cryptoplease/lib/presentation/utils.dart
+++ b/packages/cryptoplease/lib/presentation/utils.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:cryptoplease/l10n/l10n.dart';
-import 'package:cryptoplease/presentation/snackbars.dart';
+import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -20,7 +20,7 @@ extension LinkOpenerExtension on BuildContext {
     try {
       await launch(link);
     } on PlatformException catch (_) {
-      showErrorSnackbar(
+      showCpErrorSnackbar(
         this,
         message: l10n.tryAgainLater,
       );

--- a/packages/cryptoplease_ui/lib/cryptoplease_ui.dart
+++ b/packages/cryptoplease_ui/lib/cryptoplease_ui.dart
@@ -7,6 +7,7 @@ export 'src/colors.dart';
 export 'src/content_padding.dart';
 export 'src/empty_message_widget.dart';
 export 'src/loader.dart';
+export 'src/snackbar.dart';
 export 'src/switch.dart';
 export 'src/text_field.dart';
 export 'src/theme.dart';

--- a/packages/cryptoplease_ui/lib/src/snackbar.dart
+++ b/packages/cryptoplease_ui/lib/src/snackbar.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+void showCpSnackbar(
+  BuildContext context, {
+  required String message,
+  Widget? icon,
+}) {
+  final snackbar = SnackBar(
+    behavior: SnackBarBehavior.floating,
+    shape: const StadiumBorder(),
+    content: ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 24),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          if (icon != null)
+            Container(
+              height: 24,
+              margin: const EdgeInsets.only(right: 16),
+              child: icon,
+            ),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(color: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  ScaffoldMessenger.of(context).showSnackBar(snackbar);
+}
+
+void showCpErrorSnackbar(BuildContext context, {required String message}) =>
+    showCpSnackbar(
+      context,
+      message: message,
+      icon: const Icon(Icons.error, color: Colors.red),
+    );

--- a/packages/cryptoplease_ui/storybook/lib/main.dart
+++ b/packages/cryptoplease_ui/storybook/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:storybook/stories/button.dart';
 import 'package:storybook/stories/content_padding.dart';
 import 'package:storybook/stories/empty_message_widget.dart';
 import 'package:storybook/stories/loader.dart';
+import 'package:storybook/stories/snackbar.dart';
 import 'package:storybook/stories/switch.dart';
 import 'package:storybook/stories/text_field.dart';
 import 'package:storybook/stories/user_avatar.dart';
@@ -53,6 +54,7 @@ class StorybookApp extends StatelessWidget {
           cpContentPadding,
           cpEmptyMessageWidget,
           cpLoader,
+          cpSnackbar,
           cpSwitch,
           cpTextField,
           cpUserAvatar,

--- a/packages/cryptoplease_ui/storybook/lib/stories/snackbar.dart
+++ b/packages/cryptoplease_ui/storybook/lib/stories/snackbar.dart
@@ -1,0 +1,29 @@
+import 'package:cryptoplease_ui/cryptoplease_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+
+final cpSnackbar = Story(
+  name: 'CpSnackbar',
+  builder: (context) => Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ElevatedButton(
+          child: const Text('Show custom snackbar'),
+          onPressed: () => showCpSnackbar(
+            context,
+            message: 'Hello world',
+            icon: const Icon(Icons.check, color: Colors.white),
+          ),
+        ),
+        ElevatedButton(
+          child: const Text('Show error snackbar'),
+          onPressed: () => showCpErrorSnackbar(
+            context,
+            message: 'Something went wrong',
+          ),
+        ),
+      ],
+    ),
+  ),
+);


### PR DESCRIPTION
## Changes

Snackbars are now in `cryptoplease_ui` package.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
