### PR TITLE
fix: Pass initial token for link transfer

### DIFF
--- a/packages/cryptoplease/lib/presentation/screens/authenticated/send_flow/fungible_token/link_transfer_flow_screen.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/send_flow/fungible_token/link_transfer_flow_screen.dart
@@ -37,6 +37,7 @@ class _FtLinkTransferFlowScreenState extends State<FtLinkTransferFlowScreen> {
           conversionRatesRepository: context.read<ConversionRatesRepository>(),
           userCurrency: context.read<UserPreferences>().fiatCurrency,
           transferType: OutgoingTransferType.splitKey,
+          initialToken: widget.token,
         ),
         child: BlocListener<FtCreateOutgoingTransferBloc,
             FtCreateOutgoingTransferState>(


### PR DESCRIPTION
## Changes

Fix initial token parameter for link transfer.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
