### PR TITLE
fix: Make Meta innerInstructions and logMessages nullable

### DIFF
--- a/packages/solana/lib/src/rpc/dto/meta.dart
+++ b/packages/solana/lib/src/rpc/dto/meta.dart
@@ -35,7 +35,7 @@ class Meta {
 
   /// List of inner instructions or omitted if inner instruction
   /// recording was not yet enabled during this transaction.
-  final List<InnerInstruction> innerInstructions;
+  final List<InnerInstruction>? innerInstructions;
 
   /// List of token balances from before the transaction was
   /// processed or omitted if token balance recording was not yet
@@ -49,5 +49,5 @@ class Meta {
 
   /// Array of string log messages or omitted if log message
   /// recording was not yet enabled during this transaction.
-  final List<String> logMessages;
+  final List<String>? logMessages;
 }

--- a/packages/solana/lib/src/rpc/dto/meta.g.dart
+++ b/packages/solana/lib/src/rpc/dto/meta.g.dart
@@ -13,8 +13,8 @@ Meta _$MetaFromJson(Map<String, dynamic> json) => Meta(
           (json['preBalances'] as List<dynamic>).map((e) => e as int).toList(),
       postBalances:
           (json['postBalances'] as List<dynamic>).map((e) => e as int).toList(),
-      innerInstructions: (json['innerInstructions'] as List<dynamic>)
-          .map((e) => InnerInstruction.fromJson(e as Map<String, dynamic>))
+      innerInstructions: (json['innerInstructions'] as List<dynamic>?)
+          ?.map((e) => InnerInstruction.fromJson(e as Map<String, dynamic>))
           .toList(),
       preTokenBalances: (json['preTokenBalances'] as List<dynamic>)
           .map((e) => TokenBalance.fromJson(e as Map<String, dynamic>))
@@ -22,7 +22,7 @@ Meta _$MetaFromJson(Map<String, dynamic> json) => Meta(
       postTokenBalances: (json['postTokenBalances'] as List<dynamic>)
           .map((e) => TokenBalance.fromJson(e as Map<String, dynamic>))
           .toList(),
-      logMessages: (json['logMessages'] as List<dynamic>)
-          .map((e) => e as String)
+      logMessages: (json['logMessages'] as List<dynamic>?)
+          ?.map((e) => e as String)
           .toList(),
     );


### PR DESCRIPTION
Ran into an issue while trying to fetch the following transaction with this library :
`4ZbnJUyNXTqSzN535p77fjsZEWC9fJWk3jBSLij8uuTh376mQjjviVUvuLFtFzDXGTsSHAjFAiViFAweLscrve8C`

Moreover, according to the [doc](https://docs.solana.com/developing/clients/jsonrpc-api#gettransaction), `innerInstructions` and `logMessages` are `<array|null>`

Edit: Not the same issue, but Buffer.fromuint64 is not supported in dart2js (web), and it looks like they aren't going to fix it. Unfortunately many utils like `TokenInstruction.transfer` will fail in web.
[https://github.com/dart-lang/sdk/issues/10275](https://github.com/dart-lang/sdk/issues/10275)