### PR TITLE
feat: update `tokenAmount` and `splTokenTransferCheckedInfo` models

### DIFF
--- a/packages/solana/lib/src/rpc/dto/parsed_message/spl_token_transfer_checked_info.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/spl_token_transfer_checked_info.dart
@@ -12,6 +12,9 @@ class SplTokenTransferCheckedInfo {
     required this.tokenAmount,
     required this.source,
     required this.destination,
+    required this.mint,
+    required this.multisigAuthority,
+    required this.signers,
   });
 
   factory SplTokenTransferCheckedInfo.fromJson(
@@ -22,4 +25,7 @@ class SplTokenTransferCheckedInfo {
   final TokenAmount tokenAmount;
   final String source;
   final String destination;
+  final String mint;
+  final String multisigAuthority;
+  final List<String> signers;
 }

--- a/packages/solana/lib/src/rpc/dto/parsed_message/spl_token_transfer_checked_info.g.dart
+++ b/packages/solana/lib/src/rpc/dto/parsed_message/spl_token_transfer_checked_info.g.dart
@@ -13,6 +13,10 @@ SplTokenTransferCheckedInfo _$SplTokenTransferCheckedInfoFromJson(
           TokenAmount.fromJson(json['tokenAmount'] as Map<String, dynamic>),
       source: json['source'] as String,
       destination: json['destination'] as String,
+      mint: json['mint'] as String,
+      multisigAuthority: json['multisigAuthority'] as String,
+      signers:
+          (json['signers'] as List<dynamic>).map((e) => e as String).toList(),
     );
 
 Map<String, dynamic> _$SplTokenTransferCheckedInfoToJson(
@@ -21,4 +25,7 @@ Map<String, dynamic> _$SplTokenTransferCheckedInfoToJson(
       'tokenAmount': instance.tokenAmount,
       'source': instance.source,
       'destination': instance.destination,
+      'mint': instance.mint,
+      'multisigAuthority': instance.multisigAuthority,
+      'signers': instance.signers,
     };

--- a/packages/solana/lib/src/rpc/dto/token_amount.dart
+++ b/packages/solana/lib/src/rpc/dto/token_amount.dart
@@ -9,6 +9,7 @@ class TokenAmount {
     required this.amount,
     required this.decimals,
     required this.uiAmountString,
+    required this.uiAmount,
   });
 
   factory TokenAmount.fromJson(Map<String, dynamic> json) =>
@@ -24,4 +25,7 @@ class TokenAmount {
 
   /// Token amount as a string, accounting for decimals.
   final String? uiAmountString;
+
+  /// Token amount as a decimal number.
+  final double uiAmount;
 }

--- a/packages/solana/lib/src/rpc/dto/token_amount.g.dart
+++ b/packages/solana/lib/src/rpc/dto/token_amount.g.dart
@@ -10,6 +10,7 @@ TokenAmount _$TokenAmountFromJson(Map<String, dynamic> json) => TokenAmount(
       amount: json['amount'] as String,
       decimals: json['decimals'] as int,
       uiAmountString: json['uiAmountString'] as String?,
+      uiAmount: (json['uiAmount'] as num).toDouble(),
     );
 
 Map<String, dynamic> _$TokenAmountToJson(TokenAmount instance) =>
@@ -17,4 +18,5 @@ Map<String, dynamic> _$TokenAmountToJson(TokenAmount instance) =>
       'amount': instance.amount,
       'decimals': instance.decimals,
       'uiAmountString': instance.uiAmountString,
+      'uiAmount': instance.uiAmount,
     };


### PR DESCRIPTION
## Changes

Current models have not included several fields, which seems to be existing in latest solana implementation.

Sample [transaction](https://explorer.solana.com/tx/3keW15m9Y5eHBrSrLdi8SoTD5AmPnGRku8Z4CRsCm3FL5KpcWjxtfhRoF6aiRxzndNRqrs3emoikd7V5AJQU8vjg?cluster=devnet).
<img width="501" alt="Screenshot 2022-05-22 at 3 46 57 PM" src="https://user-images.githubusercontent.com/12739071/169686501-38f591c7-41b6-4e0d-b63f-0cce3e9099c4.png">

After implementing changes, locally it works well.
<img width="552" alt="Screenshot 2022-05-22 at 3 51 26 PM" src="https://user-images.githubusercontent.com/12739071/169686685-526b3fdd-4bfd-450b-9926-b7798b361a15.png">


To simulate this outcome, send [USDC](https://usdcfaucet.com/) to your `devnet` wallet. It seems that `checked transfer` has several more fields. However - I have not found any full official json for these models, therefore not sure, if they can be nullable or are fixed. Would be great if someone could guide me here.

Furthermore, after running solana test suite and running `flutter test` - it simply timed out. I guess I'm not doing something correctly. Would love to get some guidance here.

## Checklist

- [ ] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
