### PR TITLE
fix: add `encoding` to `accountSubscribe`

### DIFF
--- a/packages/solana/lib/src/subscription_client/subscription_client.dart
+++ b/packages/solana/lib/src/subscription_client/subscription_client.dart
@@ -44,6 +44,7 @@ class SubscriptionClient {
   Stream<Account> accountSubscribe(
     String address, {
     Commitment? commitment,
+    Encoding encoding = Encoding.jsonParsed,
   }) =>
       _subscribe<Account>(
         'account',
@@ -53,6 +54,9 @@ class SubscriptionClient {
             <String, String>{
               'commitment': commitment.value,
             },
+          <String, String>{
+            'encoding': encoding.value,
+          },
         ],
       );
 


### PR DESCRIPTION
## Changes

Previous implementation was missing `encoding` param.
https://docs.solana.com/developing/clients/jsonrpc-api#accountsubscribe

## Related issues

N/A.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
