### PR TITLE
feat: Add method name to RpcTimeoutException

### DIFF
--- a/packages/solana/lib/src/exceptions/rpc_timeout_exception.dart
+++ b/packages/solana/lib/src/exceptions/rpc_timeout_exception.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 
 class RpcTimeoutException extends TimeoutException {
-  RpcTimeoutException(
-    this.body, {
+  RpcTimeoutException({
+    required String method,
+    required this.body,
     Duration? timeout,
-  }) : super('RPC call timed out.', timeout);
+  }) : super('RPC call $method timed out.', timeout);
 
   /// Request body.
   final dynamic body;

--- a/packages/solana/lib/src/rpc/json_rpc_client.dart
+++ b/packages/solana/lib/src/rpc/json_rpc_client.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart';
 import 'package:solana/src/exceptions/http_exception.dart';
 import 'package:solana/src/exceptions/json_rpc_exception.dart';
 import 'package:solana/src/exceptions/rpc_timeout_exception.dart';
+import 'package:solana/src/rpc/json_rpc_request.dart';
 
 class JsonRpcClient {
   JsonRpcClient(
@@ -22,7 +23,7 @@ class JsonRpcClient {
   ) async {
     final requests = params
         .map(
-          (p) => _JsonRpcSingleRequest(
+          (p) => JsonRpcSingleRequest(
             method: method,
             params: p,
             id: (_lastId++).toString(),
@@ -30,7 +31,7 @@ class JsonRpcClient {
         )
         .toList(growable: false);
 
-    final response = await _postRequest(_JsonRpcRequest.bulk(requests));
+    final response = await _postRequest(JsonRpcRequest.bulk(requests));
     if (response is _JsonRpcArrayResponse) {
       final elements = response.array;
 
@@ -47,7 +48,7 @@ class JsonRpcClient {
     String method, {
     List<dynamic>? params,
   }) async {
-    final request = _JsonRpcSingleRequest(
+    final request = JsonRpcSingleRequest(
       id: (_lastId++).toString(),
       method: method,
       params: params,
@@ -62,7 +63,7 @@ class JsonRpcClient {
   }
 
   Future<_JsonRpcResponse> _postRequest(
-    _JsonRpcRequest request,
+    JsonRpcRequest request,
   ) async {
     final body = request.toJson();
     // Perform the POST request
@@ -72,7 +73,11 @@ class JsonRpcClient {
       body: json.encode(body),
     ).timeout(
       _timeout,
-      onTimeout: () => throw RpcTimeoutException(body, timeout: _timeout),
+      onTimeout: () => throw RpcTimeoutException(
+        method: request.method,
+        body: body,
+        timeout: _timeout,
+      ),
     );
     // Handle the response
     if (response.statusCode == 200) {
@@ -81,44 +86,6 @@ class JsonRpcClient {
       throw HttpException(response.statusCode, response.body);
     }
   }
-}
-
-abstract class _JsonRpcRequest {
-  const factory _JsonRpcRequest.bulk(
-    List<_JsonRpcSingleRequest> list,
-  ) = _JsonRpcBulkRequest;
-
-  dynamic toJson();
-}
-
-class _JsonRpcBulkRequest implements _JsonRpcRequest {
-  const _JsonRpcBulkRequest(this.list);
-
-  @override
-  List<dynamic> toJson() =>
-      list.map<dynamic>((i) => i.toJson()).toList(growable: false);
-
-  final List<_JsonRpcRequest> list;
-}
-
-class _JsonRpcSingleRequest implements _JsonRpcRequest {
-  const _JsonRpcSingleRequest({
-    required this.id,
-    required this.method,
-    this.params,
-  });
-
-  @override
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        'jsonrpc': '2.0',
-        'id': id,
-        'method': method,
-        if (params != null) 'params': params,
-      };
-
-  final String id;
-  final String method;
-  final List<dynamic>? params;
 }
 
 abstract class _JsonRpcResponse {

--- a/packages/solana/lib/src/rpc/json_rpc_request.dart
+++ b/packages/solana/lib/src/rpc/json_rpc_request.dart
@@ -1,0 +1,45 @@
+abstract class JsonRpcRequest {
+  const factory JsonRpcRequest.bulk(
+    List<JsonRpcSingleRequest> list,
+  ) = JsonRpcBulkRequest;
+
+  String get method;
+
+  dynamic toJson();
+}
+
+class JsonRpcBulkRequest implements JsonRpcRequest {
+  const JsonRpcBulkRequest(this.list);
+
+  @override
+  List<dynamic> toJson() =>
+      list.map<dynamic>((i) => i.toJson()).toList(growable: false);
+
+  final List<JsonRpcRequest> list;
+
+  @override
+  String get method => '[${list.map((e) => e.method).join(', ')}]';
+}
+
+class JsonRpcSingleRequest implements JsonRpcRequest {
+  const JsonRpcSingleRequest({
+    required this.id,
+    required this.method,
+    this.params,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'jsonrpc': '2.0',
+        'id': id,
+        'method': method,
+        if (params != null) 'params': params,
+      };
+
+  final String id;
+
+  @override
+  final String method;
+
+  final List<dynamic>? params;
+}

--- a/packages/solana/test/rpc_client_test.dart
+++ b/packages/solana/test/rpc_client_test.dart
@@ -11,9 +11,52 @@ import 'config.dart';
 const int _transferredAmount = lamportsPerSol;
 
 void main() {
-  test('throws exception on timeout', () async {
-    final client = RpcClient(devnetRpcUrl, timeout: Duration.zero);
-    expect(client.getTransactionCount, throwsA(isA<TimeoutException>()));
+  group('Timeout exceptions', () {
+    test('throws exception with method name on timeout', () async {
+      final client = RpcClient(devnetRpcUrl, timeout: Duration.zero);
+
+      expect(
+        client.getTransactionCount(),
+        throwsA(
+          isA<RpcTimeoutException>().having(
+            (e) => e.message,
+            'message',
+            'RPC call getTransactionCount timed out.',
+          ),
+        ),
+      );
+    });
+
+    test('throws exception with bulk method names on timeout', () async {
+      final client = RpcClient(devnetRpcUrl, timeout: Duration.zero);
+      const transactions = [
+        TransactionSignatureInformation(
+          signature: 'signature',
+          slot: 0,
+          err: null,
+          memo: null,
+          blockTime: null,
+        ),
+        TransactionSignatureInformation(
+          signature: 'signature',
+          slot: 0,
+          err: null,
+          memo: null,
+          blockTime: null,
+        ),
+      ];
+
+      expect(
+        client.getMultipleTransactions(transactions),
+        throwsA(
+          isA<RpcTimeoutException>().having(
+            (e) => e.message,
+            'message',
+            'RPC call [getTransaction, getTransaction] timed out.',
+          ),
+        ),
+      );
+    });
   });
 
   group('RpcClient testsuite', () {


### PR DESCRIPTION
## Changes

Added method names to `RpcTimeoutException` for easier debugging, e.g.

```
TimeoutException after 0:00:00.000000: RPC call getTransactionCount timed out.
TimeoutException after 0:00:00.000000: RPC call [getTransaction, getTransaction] timed out.
```

## Related issues

As per discussion here: https://github.com/cryptoplease/cryptoplease-dart/pull/285#issuecomment-1146707928

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [x] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
