### PR TITLE
fix: Make `err` in TransactionStatus dynamic

### DIFF
--- a/packages/solana/lib/src/rpc/dto/transaction_status.dart
+++ b/packages/solana/lib/src/rpc/dto/transaction_status.dart
@@ -10,12 +10,14 @@ class TransactionStatus {
     required this.err,
     required this.logs,
     required this.accounts,
+    required this.unitsConsumed,
   });
 
   factory TransactionStatus.fromJson(Map<String, dynamic> json) =>
       _$TransactionStatusFromJson(json);
 
-  final Map<String, dynamic>? err;
+  /// Error if transaction failed, null if transaction succeeded.
+  final dynamic err;
 
   /// Array of log messages the transaction instructions output during
   /// execution, null if simulation failed before the transaction was able to
@@ -23,7 +25,11 @@ class TransactionStatus {
   /// failure).
   final List<String>? logs;
 
-  /// Array of [Account]s with the same length as the
-  /// `SimulateTransactionAccounts.addresses` array in the request.
+  /// Array of accounts with the same length as the `accounts.addresses` array
+  /// in the request.
   final List<Account>? accounts;
+
+  /// The number of compute budget units consumed during the processing of this
+  /// transaction.
+  final int? unitsConsumed;
 }

--- a/packages/solana/lib/src/rpc/dto/transaction_status.g.dart
+++ b/packages/solana/lib/src/rpc/dto/transaction_status.g.dart
@@ -8,9 +8,10 @@ part of 'transaction_status.dart';
 
 TransactionStatus _$TransactionStatusFromJson(Map<String, dynamic> json) =>
     TransactionStatus(
-      err: json['err'] as Map<String, dynamic>?,
+      err: json['err'],
       logs: (json['logs'] as List<dynamic>?)?.map((e) => e as String).toList(),
       accounts: (json['accounts'] as List<dynamic>?)
           ?.map((e) => Account.fromJson(e as Map<String, dynamic>))
           .toList(),
+      unitsConsumed: json['unitsConsumed'] as int?,
     );


### PR DESCRIPTION
## Changes

`err` in `simulateTransaction` response can be of type `<object | string | null>`, so it's now of type `dynamic`.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
