### PR TITLE
fix: improves swap ux flow

### DIFF
--- a/packages/cryptoplease/lib/bl/swap_tokens/transaction/swap_transaction_bloc.dart
+++ b/packages/cryptoplease/lib/bl/swap_tokens/transaction/swap_transaction_bloc.dart
@@ -20,8 +20,6 @@ typedef _State = SwapTransactionState;
 typedef _EventHandler = EventHandler<_Event, _State>;
 typedef _Emitter = Emitter<_State>;
 
-const _transactionTimeout = Duration(seconds: 60);
-
 class SwapTransactionBloc
     extends Bloc<SwapTransactionEvent, SwapTransactionState> {
   SwapTransactionBloc({
@@ -146,7 +144,7 @@ class SwapTransactionBloc
       await _solanaClient.waitForSignatureStatus(
         signature,
         status: Commitment.confirmed,
-        timeout: _transactionTimeout,
+        timeout: const Duration(minutes: 1),
       );
 
       return signature;

--- a/packages/cryptoplease/lib/bl/swap_tokens/transaction/swap_transaction_bloc.dart
+++ b/packages/cryptoplease/lib/bl/swap_tokens/transaction/swap_transaction_bloc.dart
@@ -20,6 +20,8 @@ typedef _State = SwapTransactionState;
 typedef _EventHandler = EventHandler<_Event, _State>;
 typedef _Emitter = Emitter<_State>;
 
+const _transactionTimeout = Duration(seconds: 60);
+
 class SwapTransactionBloc
     extends Bloc<SwapTransactionEvent, SwapTransactionState> {
   SwapTransactionBloc({
@@ -144,6 +146,7 @@ class SwapTransactionBloc
       await _solanaClient.waitForSignatureStatus(
         signature,
         status: Commitment.confirmed,
+        timeout: _transactionTimeout,
       );
 
       return signature;

--- a/packages/cryptoplease/lib/presentation/screens/authenticated/home_tabs_screen.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/home_tabs_screen.dart
@@ -45,12 +45,12 @@ class _HomeTabsScreenState extends State<HomeTabsScreen> {
               onPressed: () => _onBottomNavigatorItemTap(1),
             ),
             NavigationButton(
-              icon: Assets.icons.notifications,
+              icon: Assets.icons.swap,
               active: _currentPage == 2,
               onPressed: () => _onBottomNavigatorItemTap(2),
             ),
             NavigationButton(
-              icon: Assets.icons.swap,
+              icon: Assets.icons.notifications,
               active: _currentPage == 3,
               onPressed: () => _onBottomNavigatorItemTap(3),
             ),
@@ -70,11 +70,11 @@ const _pages = [
   _Page(route: WalletRoute(), overlayStyle: SystemUiOverlayStyle.light),
   _Page(route: NftRoute(), overlayStyle: SystemUiOverlayStyle.light),
   _Page(
-    route: ActivitiesRoute(),
+    route: SwapTokenFlowRoute(),
     overlayStyle: SystemUiOverlayStyle.dark,
   ),
   _Page(
-    route: SwapTokenFlowRoute(),
+    route: ActivitiesRoute(),
     overlayStyle: SystemUiOverlayStyle.dark,
   ),
   _Page(route: ProfileRoute(), overlayStyle: SystemUiOverlayStyle.dark),

--- a/packages/cryptoplease/lib/presentation/screens/authenticated/swap_tokens/components/token_dropdown.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/swap_tokens/components/token_dropdown.dart
@@ -65,7 +65,7 @@ class _TokenMini extends StatelessWidget {
             ),
             Flexible(
               child: Text(
-                token.name,
+                token.symbol,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/packages/cryptoplease/lib/presentation/screens/authenticated/swap_tokens/screens/swap_token_order_screen.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/swap_tokens/screens/swap_token_order_screen.dart
@@ -12,7 +12,6 @@ import 'package:cryptoplease/presentation/screens/authenticated/swap_tokens/slip
 import 'package:cryptoplease/presentation/screens/authenticated/swap_tokens/swap_token_flow.dart';
 import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:decimal/decimal.dart';
-import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:jupiter_aggregator/jupiter_aggregator.dart';
@@ -60,38 +59,38 @@ class _ContentState extends State<_Content> {
   }
 
   @override
-  Widget build(BuildContext context) => CpLoader(
-        isLoading: context.select<SwapSelectorBloc, bool>(
-          (b) => b.state.maybeMap(uninitialized: T, orElse: F),
-        ),
-        child: BlocListener<SwapSelectorBloc, SwapSelectorState>(
-          listenWhen: (previous, current) =>
-              previous.routeProcessingState != current.routeProcessingState,
-          listener: (context, state) {
-            state.whenOrNull(
-              success: (route) =>
-                  context.read<SwapTokenRouter>().onSubmit(route),
-            );
-            state.routeProcessingState?.whenOrNull(
-              error: (error) => showSwapErrorDialog(
-                context,
-                context.l10n.errorLoadingTokens,
-                error,
+  Widget build(BuildContext context) =>
+      BlocListener<SwapSelectorBloc, SwapSelectorState>(
+        listenWhen: (previous, current) =>
+            previous.routeProcessingState != current.routeProcessingState,
+        listener: (context, state) {
+          state.whenOrNull(
+            success: (route) => context.read<SwapTokenRouter>().onSubmit(route),
+          );
+          state.routeProcessingState?.whenOrNull(
+            error: (error) => showSwapErrorDialog(
+              context,
+              context.l10n.errorLoadingTokens,
+              error,
+            ),
+          );
+        },
+        child: Scaffold(
+          appBar: CpAppBar(
+            title: Text(context.l10n.swapTokens),
+            leading: BlocBuilder<SwapSelectorBloc, SwapSelectorState>(
+              builder: (context, state) => state.maybeMap(
+                uninitialized: (_) => const _Loading(),
+                orElse: () => const _SettingsButton(),
               ),
-            );
-          },
-          child: Scaffold(
-            appBar: CpAppBar(
-              title: Text(context.l10n.swapTokens),
-              leading: const _SettingsButton(),
-              nextButton: const _SubmitButton(),
             ),
-            body: Column(
-              children: [
-                _Header(controller: _inputController),
-                Flexible(child: _Keypad(controller: _inputController)),
-              ],
-            ),
+            nextButton: const _SubmitButton(),
+          ),
+          body: Column(
+            children: [
+              _Header(controller: _inputController),
+              Flexible(child: _Keypad(controller: _inputController)),
+            ],
           ),
         ),
       );
@@ -199,6 +198,20 @@ class _Keypad extends StatelessWidget {
           controller: controller,
           maxDecimals: context.select<SwapSelectorBloc, int>(
             (b) => b.state.input?.decimals ?? 2,
+          ),
+        ),
+      );
+}
+
+class _Loading extends StatelessWidget {
+  const _Loading({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) => const Center(
+        child: SizedBox.square(
+          dimension: 16.0,
+          child: CircularProgressIndicator(
+            color: Colors.white,
           ),
         ),
       );

--- a/packages/cryptoplease/lib/presentation/screens/authenticated/swap_tokens/screens/swap_token_selector_screen.dart
+++ b/packages/cryptoplease/lib/presentation/screens/authenticated/swap_tokens/screens/swap_token_selector_screen.dart
@@ -37,7 +37,9 @@ class _SelectorState extends State<SwapTokenSelectorScreen> {
 
     final query = text.toLowerCase();
     final filtered = widget.availableTokens.where(
-      (token) => token.name.toLowerCase().contains(query),
+      (token) =>
+          token.name.toLowerCase().contains(query) ||
+          token.symbol.toLowerCase().contains(query),
     );
     setState(() => _tokenList = filtered);
   }

--- a/packages/cryptoplease_ui/lib/src/button.dart
+++ b/packages/cryptoplease_ui/lib/src/button.dart
@@ -66,7 +66,7 @@ class CpButton extends StatelessWidget {
         case CpButtonSize.small:
           return style.copyWith(fontSize: 17, height: 1);
         case CpButtonSize.micro:
-          return style.copyWith(fontSize: 15, height: 1);
+          return style.copyWith(fontSize: 15, height: 1.5);
       }
     })();
 


### PR DESCRIPTION
## Changes

- [x] the swap page should be the third icon on the bottom menu
- [x] I should be able to search token by ticker like USDC (instead of USD Coin)
- [x] each time we open the swap page we have a strange spinner, we can remove that? it makes the UX not fluid
- [x] Solana token is not available in the list of token
- [x] Display the ticker name instead of the long name of the token in the swap page
- [x] In the SWAP button, the swap text is not properly vertical-align center
- [x] increase timeout limit to 60sec

## Related issues

Fixes parts of #293 

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
