### PR TITLE
fix: Fix iOS deeplink parsing on start

### DIFF
--- a/packages/cryptoplease/lib/app/screens/dynamic_links/install_link_manager.dart
+++ b/packages/cryptoplease/lib/app/screens/dynamic_links/install_link_manager.dart
@@ -12,11 +12,14 @@ class InstallLinkManager {
   Future<Uri?> getInstallReferrer() async {
     final prefs = await SharedPreferences.getInstance();
     final isFirstLaunch = prefs.getBool(_key) ?? true;
-    if (!isFirstLaunch) return null;
-
-    await prefs.setBool(_key, false);
+    if (isFirstLaunch) {
+      await prefs.setBool(_key, false);
+    }
 
     if (Platform.isIOS) {
+      final hasStrings = await Clipboard.hasStrings();
+      if (!hasStrings) return null;
+
       final uri = await Clipboard.getData('text/plain')
           .then((it) => it?.text ?? '')
           .then(Uri.tryParse);
@@ -27,6 +30,8 @@ class InstallLinkManager {
         return uri;
       }
     } else if (Platform.isAndroid) {
+      if (!isFirstLaunch) return null;
+
       final result = await _platform.invokeMethod<String>('getInstallReferrer');
 
       return Uri.tryParse(result ?? '');


### PR DESCRIPTION
## Changes

Fixed iOS deeplink parsing on app start, it should work not only on the first launch.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
