### PR TITLE
fix: add padding at the bottom of 'Select Token' list

### DIFF
--- a/packages/cryptoplease/lib/core/presentation/token_selector_screen.dart
+++ b/packages/cryptoplease/lib/core/presentation/token_selector_screen.dart
@@ -1,4 +1,5 @@
 import 'package:cryptoplease/app/components/token_icon.dart';
+import 'package:cryptoplease/app/screens/authenticated/components/navigation_bar/navigation_bar.dart';
 import 'package:cryptoplease/core/amount.dart';
 import 'package:cryptoplease/core/balances/presentation/watch_balance.dart';
 import 'package:cryptoplease/core/presentation/format_amount.dart';
@@ -148,20 +149,23 @@ class _TokenList extends StatelessWidget {
   final bool shouldDisplayAmount;
 
   @override
-  Widget build(BuildContext context) => SliverList(
-        delegate: SliverChildBuilderDelegate(
-          (context, index) {
-            final token = tokens.elementAt(index);
+  Widget build(BuildContext context) => SliverPadding(
+        padding: const EdgeInsets.only(bottom: cpNavigationBarheight),
+        sliver: SliverList(
+          delegate: SliverChildBuilderDelegate(
+            (context, index) {
+              final token = tokens.elementAt(index);
 
-            return _SelectableBalanceItem(
-              token: token,
-              onSelect: onTokenSelected,
-              balance: shouldDisplayAmount
-                  ? context.watchUserCryptoBalance(token)
-                  : null,
-            );
-          },
-          childCount: tokens.length,
+              return _SelectableBalanceItem(
+                token: token,
+                onSelect: onTokenSelected,
+                balance: shouldDisplayAmount
+                    ? context.watchUserCryptoBalance(token)
+                    : null,
+              );
+            },
+            childCount: tokens.length,
+          ),
         ),
       );
 }


### PR DESCRIPTION
## Changes

Wrapped SliverList widget in the `TokenList` with SliverPadding and provided it a bottom padding value of 64.

## Related issues

Fixes #389 

### Screenshot
![photo_6075849260672332232_y](https://user-images.githubusercontent.com/36201975/187020830-7f32fdaa-e226-4776-b2f5-e851e882da03.jpeg)



## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
