### PR TITLE
fix: add default value for version

### DIFF
--- a/packages/cryptoplease/lib/features/incoming_split_key_payment/bl/models.dart
+++ b/packages/cryptoplease/lib/features/incoming_split_key_payment/bl/models.dart
@@ -13,7 +13,7 @@ class SplitKeyIncomingFirstPart with _$SplitKeyIncomingFirstPart {
   const factory SplitKeyIncomingFirstPart({
     required String keyPart,
     required String tokenAddress,
-    required SplitKeyApiVersion apiVersion,
+    @Default(SplitKeyApiVersion.v1) SplitKeyApiVersion apiVersion,
   }) = _SplitKeyIncomingFirstPart;
 
   factory SplitKeyIncomingFirstPart.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
## Changes

Added default version value to `SplitKeyIncomingFirstPart`.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
