### PR TITLE
refactor: move jupiter client to cryptoplease_api package

### DIFF
--- a/packages/cryptoplease/lib/features/swap_tokens/bl/selector/swap_selector_bloc.dart
+++ b/packages/cryptoplease/lib/features/swap_tokens/bl/selector/swap_selector_bloc.dart
@@ -9,13 +9,13 @@ import 'package:cryptoplease/core/processing_state.dart';
 import 'package:cryptoplease/core/tokens/token.dart';
 import 'package:cryptoplease/core/tokens/token_list.dart';
 import 'package:cryptoplease/features/swap_tokens/bl/swap_exception.dart';
+import 'package:cryptoplease_api/cryptoplease_api.dart';
 import 'package:decimal/decimal.dart';
 import 'package:dfunc/dfunc.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 import 'package:rxdart/rxdart.dart';
 
 part 'swap_selector_bloc.freezed.dart';

--- a/packages/cryptoplease/lib/features/swap_tokens/bl/swap_exception.dart
+++ b/packages/cryptoplease/lib/features/swap_tokens/bl/swap_exception.dart
@@ -1,6 +1,6 @@
 import 'package:cryptoplease/core/amount.dart';
+import 'package:cryptoplease_api/cryptoplease_api.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 
 part 'swap_exception.freezed.dart';
 

--- a/packages/cryptoplease/lib/features/swap_tokens/bl/transaction/swap_transaction_bloc.dart
+++ b/packages/cryptoplease/lib/features/swap_tokens/bl/transaction/swap_transaction_bloc.dart
@@ -1,11 +1,11 @@
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:cryptoplease/core/accounts/bl/account.dart';
 import 'package:cryptoplease/features/swap_tokens/bl/swap_exception.dart';
+import 'package:cryptoplease_api/cryptoplease_api.dart';
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 import 'package:solana/encoder.dart';
 import 'package:solana/solana.dart';
 

--- a/packages/cryptoplease/lib/features/swap_tokens/presentation/screens/swap_token_order_screen.dart
+++ b/packages/cryptoplease/lib/features/swap_tokens/presentation/screens/swap_token_order_screen.dart
@@ -14,11 +14,11 @@ import 'package:cryptoplease/features/swap_tokens/presentation/components/swap_h
 import 'package:cryptoplease/features/swap_tokens/presentation/swap_token_flow.dart';
 import 'package:cryptoplease/l10n/device_locale.dart';
 import 'package:cryptoplease/l10n/l10n.dart';
+import 'package:cryptoplease_api/cryptoplease_api.dart';
 import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:decimal/decimal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 
 class SwapTokenOrderScreen extends StatelessWidget {
   const SwapTokenOrderScreen({Key? key}) : super(key: key);

--- a/packages/cryptoplease/lib/features/swap_tokens/presentation/screens/swap_token_process_screen.dart
+++ b/packages/cryptoplease/lib/features/swap_tokens/presentation/screens/swap_token_process_screen.dart
@@ -4,10 +4,10 @@ import 'package:cryptoplease/features/swap_tokens/bl/transaction/swap_transactio
 import 'package:cryptoplease/features/swap_tokens/presentation/components/swap_error_dialog.dart';
 import 'package:cryptoplease/features/swap_tokens/presentation/components/swap_step_widget.dart';
 import 'package:cryptoplease/l10n/l10n.dart';
+import 'package:cryptoplease_api/cryptoplease_api.dart';
 import 'package:dfunc/dfunc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 import 'package:solana/solana.dart';
 
 class SwapTokenProcessScreen extends StatelessWidget {

--- a/packages/cryptoplease/lib/features/swap_tokens/presentation/swap_token_flow.dart
+++ b/packages/cryptoplease/lib/features/swap_tokens/presentation/swap_token_flow.dart
@@ -1,9 +1,9 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:cryptoplease/app/routes.dart';
 import 'package:cryptoplease/core/tokens/token.dart';
+import 'package:cryptoplease_api/cryptoplease_api.dart';
 import 'package:cryptoplease_ui/cryptoplease_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 import 'package:provider/provider.dart';
 
 abstract class SwapTokenRouter {

--- a/packages/cryptoplease/lib/main.dart
+++ b/packages/cryptoplease/lib/main.dart
@@ -18,7 +18,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:jupiter_aggregator/jupiter_aggregator.dart';
 import 'package:provider/provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/cryptoplease/pubspec.lock
+++ b/packages/cryptoplease/pubspec.lock
@@ -765,7 +765,7 @@ packages:
     source: hosted
     version: "6.3.1"
   jupiter_aggregator:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: jupiter_aggregator
       url: "https://pub.dartlang.org"

--- a/packages/cryptoplease/pubspec.yaml
+++ b/packages/cryptoplease/pubspec.yaml
@@ -38,7 +38,6 @@ dependencies:
   image_picker: ^0.8.5+3
   intl: ^0.17.0
   json_annotation: ^4.4.0
-  jupiter_aggregator: ^1.0.0
   logging: ^1.0.2
   meta: ^1.7.0
   mews_pedantic: ^0.8.0

--- a/packages/cryptoplease_link/cryptoplease_api/lib/cryptoplease_api.dart
+++ b/packages/cryptoplease_link/cryptoplease_api/lib/cryptoplease_api.dart
@@ -1,5 +1,7 @@
 library cryptoplease_api;
 
+export 'package:jupiter_aggregator/jupiter_aggregator.dart';
+
 export 'src/client.dart';
 export 'src/dto/add_funds.dart';
 export 'src/dto/create_payment.dart';

--- a/packages/cryptoplease_link/cryptoplease_api/pubspec.yaml
+++ b/packages/cryptoplease_link/cryptoplease_api/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   dio: ^4.0.0
   freezed_annotation: ^2.0.1
   json_annotation: ^4.6.0
+  jupiter_aggregator: ^1.0.0
   retrofit: ^3.0.1
 
 dev_dependencies:

--- a/packages/cryptoplease_link/pubspec.lock
+++ b/packages/cryptoplease_link/pubspec.lock
@@ -351,6 +351,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.3.1"
+  jupiter_aggregator:
+    dependency: transitive
+    description:
+      name: jupiter_aggregator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   logging:
     dependency: transitive
     description:


### PR DESCRIPTION
## Changes

- Move Jupiter API lib to Cryptoplease API package

## Related issues

First step to resolve on #448

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
