### PR TITLE
fix: adjusted vertical align for copy button

### DIFF
--- a/packages/cryptoplease/lib/app/components/recovery_phrase_text_view.dart
+++ b/packages/cryptoplease/lib/app/components/recovery_phrase_text_view.dart
@@ -48,6 +48,7 @@ class RecoveryPhraseTextView extends StatelessWidget {
                       Clipboard.setData(data);
                       showClipboardSnackbar(context);
                     },
+                    size: CpButtonSize.micro,
                   ),
                 ),
               ),


### PR DESCRIPTION
## Changes

- Adjust copy button text size to align vertically

## Related issues

Fixes #473

## Screenshots

![Simulator Screen Shot - iPhone 13 - 2022-10-01 at 21 12 10](https://user-images.githubusercontent.com/28533130/193411477-a1ab0696-a077-434f-b0ab-5280f5022224.png)


## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
