### PR TITLE
feat: add txId to success statuses

### DIFF
--- a/packages/cryptoplease/lib/features/incoming_split_key_payments/bl/bloc.dart
+++ b/packages/cryptoplease/lib/features/incoming_split_key_payments/bl/bloc.dart
@@ -140,7 +140,7 @@ class ISKPBloc extends Bloc<_Event, _State> {
     final result = await _txSender.wait(txId);
 
     return result.map(
-      success: (_) => const ISKPStatus.success(),
+      success: (_) => ISKPStatus.success(txId: txId),
       failure: (_) => const ISKPStatus.txEscrowFailure(),
       networkError: (_) => ISKPStatus.txWaitFailure(txId),
     );

--- a/packages/cryptoplease/lib/features/incoming_split_key_payments/bl/incoming_split_key_payment.dart
+++ b/packages/cryptoplease/lib/features/incoming_split_key_payments/bl/incoming_split_key_payment.dart
@@ -28,7 +28,7 @@ class ISKPStatus with _$ISKPStatus {
   const factory ISKPStatus.txSent(String txId) = ISKPStatusTxSent;
 
   /// Final state. Tx is successfully confirmed and payment is claimed.
-  const factory ISKPStatus.success() = ISKPStatusSuccess;
+  const factory ISKPStatus.success({required String txId}) = ISKPStatusSuccess;
 
   /// Failed to create the tx, a new tx should be created.
   const factory ISKPStatus.txFailure() = ISKPStatusTxFailure;

--- a/packages/cryptoplease/lib/features/outgoing_direct_payments/bl/bloc.dart
+++ b/packages/cryptoplease/lib/features/outgoing_direct_payments/bl/bloc.dart
@@ -147,7 +147,7 @@ class ODPBloc extends Bloc<_Event, _State> {
     final result = await _txSender.wait(txId);
 
     return result.map(
-      success: (_) => const ODPStatus.success(),
+      success: (_) => ODPStatus.success(txId: txId),
       failure: (_) => const ODPStatus.txFailure(),
       networkError: (_) => ODPStatus.txWaitFailure(txId),
     );

--- a/packages/cryptoplease/lib/features/outgoing_direct_payments/bl/outgoing_direct_payment.dart
+++ b/packages/cryptoplease/lib/features/outgoing_direct_payments/bl/outgoing_direct_payment.dart
@@ -20,7 +20,7 @@ class OutgoingDirectPayment with _$OutgoingDirectPayment {
 class ODPStatus with _$ODPStatus {
   const factory ODPStatus.txCreated(SignedTx tx) = ODPStatusTxCreated;
   const factory ODPStatus.txSent(String txId) = ODPStatusTxSent;
-  const factory ODPStatus.success() = ODPStatusSuccess;
+  const factory ODPStatus.success({required String txId}) = ODPStatusSuccess;
   const factory ODPStatus.txFailure() = ODPStatusTxFailure;
   const factory ODPStatus.txSendFailure(SignedTx tx) = ODPStatusTxSendFailure;
   const factory ODPStatus.txWaitFailure(String txId) = ODPStatusTxWaitFailure;

--- a/packages/cryptoplease/lib/features/outgoing_direct_payments/data/repository.dart
+++ b/packages/cryptoplease/lib/features/outgoing_direct_payments/data/repository.dart
@@ -69,7 +69,7 @@ extension on ODPStatusDto {
       case ODPStatusDto.txSent:
         return ODPStatus.txSent(row.txId!);
       case ODPStatusDto.success:
-        return const ODPStatus.success();
+        return ODPStatus.success(txId: row.txId!);
       case ODPStatusDto.txFailure:
         return const ODPStatus.txFailure();
       case ODPStatusDto.txSendFailure:
@@ -111,5 +111,6 @@ extension on ODPStatus {
   String? toTxId() => mapOrNull(
         txSent: (it) => it.txId,
         txWaitFailure: (it) => it.txId,
+        success: (it) => it.txId,
       );
 }

--- a/packages/cryptoplease/lib/features/outgoing_split_key_payments/bl/outgoing_split_key_payment.dart
+++ b/packages/cryptoplease/lib/features/outgoing_split_key_payments/bl/outgoing_split_key_payment.dart
@@ -37,7 +37,9 @@ class OSKPStatus with _$OSKPStatus {
     required Ed25519HDKeyPair escrow,
   }) = OSKPStatusLinksReady;
 
-  const factory OSKPStatus.success() = OSKPStatusSuccess;
+  const factory OSKPStatus.success({
+    required String txId,
+  }) = OSKPStatusSuccess;
 
   const factory OSKPStatus.txFailure() = OSKPStatusTxFailure;
 

--- a/packages/cryptoplease/test/features/outgoing_direct_payments/bl/bloc_test.dart
+++ b/packages/cryptoplease/test/features/outgoing_direct_payments/bl/bloc_test.dart
@@ -78,7 +78,7 @@ Future<void> main() async {
       expect(
         repository._payments.values.first,
         isA<OutgoingDirectPayment>()
-            .having((it) => it.status, 'status', const ODPStatus.success()),
+            .having((it) => it.status, 'status', isA<ODPStatusSuccess>()),
       );
     },
   );


### PR DESCRIPTION
## Changes

Added `txId` to success statuses.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
