### PR TITLE
fix: share message wrapper layout

### DIFF
--- a/packages/cryptoplease/lib/app/components/share_message_wrapper.dart
+++ b/packages/cryptoplease/lib/app/components/share_message_wrapper.dart
@@ -23,9 +23,11 @@ class _ShareMessageWrapperState extends State<ShareMessageWrapper> {
   }
 
   @override
-  Widget build(BuildContext context) => CpRoundedRectangle(
-        margin: const EdgeInsets.symmetric(vertical: 24),
-        child: Padding(
+  Widget build(BuildContext context) => SizedBox(
+        width: double.infinity,
+        child: CpRoundedRectangle(
+          scrollable: true,
+          margin: const EdgeInsets.symmetric(vertical: 24),
           padding: const EdgeInsets.symmetric(
             horizontal: 32,
             vertical: 48,

--- a/packages/cryptoplease/lib/core/presentation/utils.dart
+++ b/packages/cryptoplease/lib/core/presentation/utils.dart
@@ -28,3 +28,8 @@ extension ClipboardExt on BuildContext {
     showClipboardSnackbar(this);
   }
 }
+
+extension StringExt on String {
+  String withZeroWidthSpaces() =>
+      splitMapJoin('', onMatch: (m) => '${m.group(0)}\u200b');
+}

--- a/packages/cryptoplease/lib/features/outgoing_split_key_payments/presentation/share_links_screen.dart
+++ b/packages/cryptoplease/lib/features/outgoing_split_key_payments/presentation/share_links_screen.dart
@@ -2,6 +2,7 @@ import 'package:cryptoplease/app/components/share_message/header.dart';
 import 'package:cryptoplease/app/components/share_message_wrapper.dart';
 import 'package:cryptoplease/core/amount.dart';
 import 'package:cryptoplease/core/presentation/format_amount.dart';
+import 'package:cryptoplease/core/presentation/utils.dart';
 import 'package:cryptoplease/features/outgoing_split_key_payments/bl/outgoing_split_key_payment.dart';
 import 'package:cryptoplease/l10n/l10n.dart';
 import 'package:cryptoplease/ui/app_bar.dart';
@@ -104,11 +105,17 @@ class _Links extends StatelessWidget {
           children: [
             TextSpan(text: context.l10n.shareStep1),
             _newLine,
-            TextSpan(text: firstLink.toString(), style: _linkStyle),
+            TextSpan(
+              text: firstLink.toString().withZeroWidthSpaces(),
+              style: _linkStyle,
+            ),
             _newLine,
             TextSpan(text: context.l10n.shareStep2),
             _newLine,
-            TextSpan(text: secondLink.toString(), style: _linkStyle),
+            TextSpan(
+              text: secondLink.toString().withZeroWidthSpaces(),
+              style: _linkStyle,
+            ),
           ],
           style: _baseStyle,
         ),

--- a/packages/cryptoplease/lib/features/payment_request/presentation/link_details/share_link.dart
+++ b/packages/cryptoplease/lib/features/payment_request/presentation/link_details/share_link.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:cryptoplease/app/components/share_message/header.dart';
 import 'package:cryptoplease/app/components/share_message_wrapper.dart';
 import 'package:cryptoplease/core/presentation/format_amount.dart';
+import 'package:cryptoplease/core/presentation/utils.dart';
 import 'package:cryptoplease/core/tokens/token_list.dart';
 import 'package:cryptoplease/di.dart';
 import 'package:cryptoplease/features/payment_request/bl/payment_request.dart';
@@ -118,7 +119,7 @@ class _Links extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Text.rich(
         TextSpan(
-          text: link,
+          text: link.withZeroWidthSpaces(),
           style: const TextStyle(
             fontSize: 18,
             fontWeight: FontWeight.w600,

--- a/packages/cryptoplease/lib/ui/rounded_rectangle.dart
+++ b/packages/cryptoplease/lib/ui/rounded_rectangle.dart
@@ -2,33 +2,56 @@ import 'package:cryptoplease/ui/colors.dart';
 import 'package:flutter/material.dart';
 
 /// Container that has all but top-right corner rounded.
-class CpRoundedRectangle extends StatelessWidget {
+class CpRoundedRectangle extends StatefulWidget {
   const CpRoundedRectangle({
     super.key,
     required this.child,
     this.backgroundColor,
     this.margin,
     this.padding,
+    this.scrollable = false,
   });
 
   final Widget child;
   final Color? backgroundColor;
   final EdgeInsetsGeometry? padding;
   final EdgeInsetsGeometry? margin;
+  final bool scrollable;
+
+  @override
+  State<CpRoundedRectangle> createState() => _CpRoundedRectangleState();
+}
+
+class _CpRoundedRectangleState extends State<CpRoundedRectangle> {
+  late final _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) => Container(
-        margin: margin,
-        padding: padding,
+        margin: widget.margin,
+        padding: widget.padding,
         decoration: BoxDecoration(
-          color: backgroundColor ?? CpColors.darkBackground,
+          color: widget.backgroundColor ?? CpColors.darkBackground,
           borderRadius: const BorderRadius.only(
             bottomLeft: _radius,
             bottomRight: _radius,
             topLeft: _radius,
           ),
         ),
-        child: child,
+        child: widget.scrollable
+            ? RawScrollbar(
+                thumbVisibility: true,
+                thickness: 8,
+                thumbColor: const Color(0xff525252),
+                crossAxisMargin: -24,
+                radius: const Radius.circular(9),
+                controller: _scrollController,
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.zero,
+                  controller: _scrollController,
+                  child: widget.child,
+                ),
+              )
+            : widget.child,
       );
 }
 


### PR DESCRIPTION
## Changes

Updated layout for `ShareMessageWrapper` to include scrollbar when needed.

<details>

![image](https://user-images.githubusercontent.com/853356/197605579-c42d4e1c-de59-466b-bb09-e64ff5715291.png)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
