### PR TITLE
fix: menu screen background

### DIFF
--- a/packages/cryptoplease/lib/app/screens/authenticated/profile/menu_screen.dart
+++ b/packages/cryptoplease/lib/app/screens/authenticated/profile/menu_screen.dart
@@ -24,16 +24,19 @@ class MenuScreen extends StatelessWidget {
             onRefresh: onRefresh,
             backgroundColor: Colors.white,
             color: CpColors.primaryColor,
-            child: DecoratedBox(
-              decoration: _menuScreenBackground,
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.only(bottom: cpNavigationBarheight),
-                child: Column(
-                  children: const [
-                    MenuHeader(),
-                    _SecuritySection(),
-                    _AboutSection(),
-                  ],
+            child: LayoutBuilder(
+              builder: (context, constraints) => Container(
+                height: constraints.maxHeight,
+                decoration: _menuScreenBackground,
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.only(bottom: cpNavigationBarheight),
+                  child: Column(
+                    children: const [
+                      MenuHeader(),
+                      _SecuritySection(),
+                      _AboutSection(),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Changes

- Fixes menu screen background

![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-10-27 at 10 32 20](https://user-images.githubusercontent.com/19499575/198298472-4a9973dd-7dae-488b-85c8-deb3190c18a0.png)

## Related issues

Fixes #570 

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
