### PR TITLE
fix: TxSender correctly waits for old txs

### DIFF
--- a/packages/cryptoplease/lib/features/incoming_split_key_payments/src/bl/incoming_split_key_payment.dart
+++ b/packages/cryptoplease/lib/features/incoming_split_key_payments/src/bl/incoming_split_key_payment.dart
@@ -25,7 +25,7 @@ class ISKPStatus with _$ISKPStatus {
   const factory ISKPStatus.txCreated(SignedTx tx) = ISKPStatusTxCreated;
 
   /// Tx is successfully sent.
-  const factory ISKPStatus.txSent(String txId) = ISKPStatusTxSent;
+  const factory ISKPStatus.txSent(SignedTx tx) = ISKPStatusTxSent;
 
   /// Final state. Tx is successfully confirmed and payment is claimed.
   const factory ISKPStatus.success({required String txId}) = ISKPStatusSuccess;
@@ -37,7 +37,7 @@ class ISKPStatus with _$ISKPStatus {
   const factory ISKPStatus.txSendFailure(SignedTx tx) = ISKPStatusTxSendFailure;
 
   /// Failed to get the confirmation about tx, waiting should be retried.
-  const factory ISKPStatus.txWaitFailure(String txId) = ISKPStatusTxWaitFailure;
+  const factory ISKPStatus.txWaitFailure(SignedTx tx) = ISKPStatusTxWaitFailure;
 
   /// Final state. Tx is failed to be confirmed and payment could not be claimed
   /// either due to invalid links or it was already claimed by someone else.

--- a/packages/cryptoplease/lib/features/incoming_split_key_payments/src/bl/iskp_repository.dart
+++ b/packages/cryptoplease/lib/features/incoming_split_key_payments/src/bl/iskp_repository.dart
@@ -7,6 +7,7 @@ import 'package:solana/base58.dart';
 import 'package:solana/encoder.dart';
 import 'package:solana/solana.dart';
 
+import '../../../../core/transactions/tx_sender.dart';
 import '../../../../data/db/db.dart';
 import '../../../../data/db/mixins.dart';
 import 'incoming_split_key_payment.dart';
@@ -81,7 +82,7 @@ extension on ISKPStatusDto {
       case ISKPStatusDto.txCreated:
         return ISKPStatus.txCreated(tx!);
       case ISKPStatusDto.txSent:
-        return ISKPStatus.txSent(txId!);
+        return ISKPStatus.txSent(tx ?? StubSignedTx(txId!));
       case ISKPStatusDto.success:
         return ISKPStatus.success(txId: txId!);
       case ISKPStatusDto.txFailure:
@@ -89,7 +90,7 @@ extension on ISKPStatusDto {
       case ISKPStatusDto.txSendFailure:
         return ISKPStatus.txSendFailure(tx!);
       case ISKPStatusDto.txWaitFailure:
-        return ISKPStatus.txWaitFailure(txId!);
+        return ISKPStatus.txWaitFailure(tx ?? StubSignedTx(txId!));
       case ISKPStatusDto.txEscrowFailure:
         return const ISKPStatus.txEscrowFailure();
     }
@@ -123,11 +124,11 @@ extension on ISKPStatus {
   String? toTx() => mapOrNull(
         txCreated: (it) => it.tx.encode(),
         txSendFailure: (it) => it.tx.encode(),
+        txSent: (it) => it.tx.encode(),
+        txWaitFailure: (it) => it.tx.encode(),
       );
 
   String? toTxId() => mapOrNull(
-        txSent: (it) => it.txId,
         success: (it) => it.txId,
-        txWaitFailure: (it) => it.txId,
       );
 }

--- a/packages/cryptoplease/lib/features/outgoing_direct_payments/src/bl/outgoing_direct_payment.dart
+++ b/packages/cryptoplease/lib/features/outgoing_direct_payments/src/bl/outgoing_direct_payment.dart
@@ -22,10 +22,10 @@ class OutgoingDirectPayment with _$OutgoingDirectPayment {
 @freezed
 class ODPStatus with _$ODPStatus {
   const factory ODPStatus.txCreated(SignedTx tx) = ODPStatusTxCreated;
-  const factory ODPStatus.txSent(String txId) = ODPStatusTxSent;
+  const factory ODPStatus.txSent(SignedTx tx) = ODPStatusTxSent;
   const factory ODPStatus.success({required String txId}) = ODPStatusSuccess;
   const factory ODPStatus.txFailure({TxFailureReason? reason}) =
       ODPStatusTxFailure;
   const factory ODPStatus.txSendFailure(SignedTx tx) = ODPStatusTxSendFailure;
-  const factory ODPStatus.txWaitFailure(String txId) = ODPStatusTxWaitFailure;
+  const factory ODPStatus.txWaitFailure(SignedTx tx) = ODPStatusTxWaitFailure;
 }

--- a/packages/cryptoplease/lib/features/outgoing_direct_payments/src/bl/repository.dart
+++ b/packages/cryptoplease/lib/features/outgoing_direct_payments/src/bl/repository.dart
@@ -75,11 +75,13 @@ extension ODPRowExt on ODPRow {
 
 extension on ODPStatusDto {
   ODPStatus toModel(ODPRow row) {
+    final tx = row.tx?.let(SignedTx.decode);
+
     switch (this) {
       case ODPStatusDto.txCreated:
-        return ODPStatus.txCreated(SignedTx.decode(row.tx!));
+        return ODPStatus.txCreated(tx!);
       case ODPStatusDto.txSent:
-        return ODPStatus.txSent(row.txId!);
+        return ODPStatus.txSent(tx ?? StubSignedTx(row.txId!));
       case ODPStatusDto.success:
         return ODPStatus.success(txId: row.txId!);
       case ODPStatusDto.txFailure:
@@ -87,7 +89,7 @@ extension on ODPStatusDto {
       case ODPStatusDto.txSendFailure:
         return ODPStatus.txSendFailure(SignedTx.decode(row.tx!));
       case ODPStatusDto.txWaitFailure:
-        return ODPStatus.txWaitFailure(row.txId!);
+        return ODPStatus.txWaitFailure(tx ?? StubSignedTx(row.txId!));
     }
   }
 }
@@ -120,11 +122,11 @@ extension on ODPStatus {
   String? toTx() => mapOrNull(
         txCreated: (it) => it.tx.encode(),
         txSendFailure: (it) => it.tx.encode(),
+        txSent: (it) => it.tx.encode(),
+        txWaitFailure: (it) => it.tx.encode(),
       );
 
   String? toTxId() => mapOrNull(
-        txSent: (it) => it.txId,
-        txWaitFailure: (it) => it.txId,
         success: (it) => it.txId,
       );
 

--- a/packages/cryptoplease/lib/features/outgoing_split_key_payments/src/bl/outgoing_split_key_payment.dart
+++ b/packages/cryptoplease/lib/features/outgoing_split_key_payments/src/bl/outgoing_split_key_payment.dart
@@ -36,7 +36,7 @@ class OSKPStatus with _$OSKPStatus {
   }) = OSKPStatusTxCreated;
 
   const factory OSKPStatus.txSent(
-    String txId, {
+    SignedTx tx, {
     required Ed25519HDKeyPair escrow,
   }) = OSKPStatusTxSent;
 
@@ -63,7 +63,7 @@ class OSKPStatus with _$OSKPStatus {
   }) = OSKPStatusTxSendFailure;
 
   const factory OSKPStatus.txWaitFailure(
-    String txId, {
+    SignedTx tx, {
     required Ed25519HDKeyPair escrow,
   }) = OSKPStatusTxWaitFailure;
 

--- a/packages/cryptoplease/lib/features/outgoing_split_key_payments/src/bl/repository.dart
+++ b/packages/cryptoplease/lib/features/outgoing_split_key_payments/src/bl/repository.dart
@@ -100,7 +100,7 @@ extension on OSKPStatusDto {
       case OSKPStatusDto.txCreated:
         return OSKPStatus.txCreated(tx!, escrow: escrow!);
       case OSKPStatusDto.txSent:
-        return OSKPStatus.txSent(txId!, escrow: escrow!);
+        return OSKPStatus.txSent(tx ?? StubSignedTx(txId!), escrow: escrow!);
       case OSKPStatusDto.txConfirmed:
         return OSKPStatus.txConfirmed(escrow: escrow!);
       case OSKPStatusDto.linksReady:
@@ -116,7 +116,10 @@ extension on OSKPStatusDto {
       case OSKPStatusDto.txSendFailure:
         return OSKPStatus.txSendFailure(tx!, escrow: escrow!);
       case OSKPStatusDto.txWaitFailure:
-        return OSKPStatus.txWaitFailure(txId!, escrow: escrow!);
+        return OSKPStatus.txWaitFailure(
+          tx ?? StubSignedTx(txId!),
+          escrow: escrow!,
+        );
       case OSKPStatusDto.txLinksFailure:
         return OSKPStatus.txLinksFailure(escrow: escrow!);
     }
@@ -155,12 +158,12 @@ extension on OSKPStatus {
   String? toTx() => mapOrNull(
         txCreated: (it) => it.tx.encode(),
         txSendFailure: (it) => it.tx.encode(),
+        txSent: (it) => it.tx.encode(),
+        txWaitFailure: (it) => it.tx.encode(),
       );
 
   String? toTxId() => mapOrNull(
-        txSent: (it) => it.txId,
         success: (it) => it.txId,
-        txWaitFailure: (it) => it.txId,
       );
 
   Future<String?> toPrivateKey() async => this.map(

--- a/packages/cryptoplease/test/core/transactions/tx_sender_test.dart
+++ b/packages/cryptoplease/test/core/transactions/tx_sender_test.dart
@@ -100,7 +100,7 @@ Future<void> main() async {
     );
 
     await service.send(tx);
-    final result = await service.wait(tx.id);
+    final result = await service.wait(tx);
 
     expect(result, const TxWaitResult.success());
   });
@@ -121,7 +121,7 @@ Future<void> main() async {
 
     await service.send(tx);
     await client.waitForSignatureStatus(tx.id, status: Commitment.confirmed);
-    final result = await service.wait(tx.id);
+    final result = await service.wait(tx);
 
     expect(result, const TxWaitResult.success());
   });

--- a/packages/solana/test/metaplex/instructions/create_metadata_account_test.dart
+++ b/packages/solana/test/metaplex/instructions/create_metadata_account_test.dart
@@ -12,24 +12,21 @@ Future<void> main() async {
   // TODO(KB): Setup localnet with the metaplex program deployed.
   final client = createTestSolanaClient(useLocal: false);
   final owner = await Ed25519HDKeyPair.random();
-  late final Mint mint;
-
-  setUpAll(() async {
-    await client.requestAirdrop(
-      address: owner.publicKey,
-      lamports: 1 * lamportsPerSol,
-      commitment: Commitment.confirmed,
-    );
-    mint = await client.initializeMint(
-      mintAuthority: owner,
-      decimals: 0,
-      commitment: Commitment.confirmed,
-    );
-  });
 
   test(
     'creates metadata account',
     () async {
+      await client.requestAirdrop(
+        address: owner.publicKey,
+        lamports: 1 * lamportsPerSol,
+        commitment: Commitment.confirmed,
+      );
+      final mint = await client.initializeMint(
+        mintAuthority: owner,
+        decimals: 0,
+        commitment: Commitment.confirmed,
+      );
+
       final data = CreateMetadataAccountV3Data(
         name: name,
         symbol: symbol,

--- a/packages/solana/test/metaplex/instructions/create_metadata_account_test.dart
+++ b/packages/solana/test/metaplex/instructions/create_metadata_account_test.dart
@@ -12,16 +12,20 @@ Future<void> main() async {
   // TODO(KB): Setup localnet with the metaplex program deployed.
   final client = createTestSolanaClient(useLocal: false);
   final owner = await Ed25519HDKeyPair.random();
-  await client.requestAirdrop(
-    address: owner.publicKey,
-    lamports: 1 * lamportsPerSol,
-    commitment: Commitment.confirmed,
-  );
-  final mint = await client.initializeMint(
-    mintAuthority: owner,
-    decimals: 0,
-    commitment: Commitment.confirmed,
-  );
+  late final Mint mint;
+
+  setUpAll(() async {
+    await client.requestAirdrop(
+      address: owner.publicKey,
+      lamports: 1 * lamportsPerSol,
+      commitment: Commitment.confirmed,
+    );
+    mint = await client.initializeMint(
+      mintAuthority: owner,
+      decimals: 0,
+      commitment: Commitment.confirmed,
+    );
+  });
 
   test(
     'creates metadata account',


### PR DESCRIPTION
## Changes

If there was an error during waiting for tx status, and user retries after some time, it would never succeed because no status change would be reported. This PR check that the tx already exists on the blockchain and checks its status. If the tx doesn't exist and its blockhash is not valid anymore, it's safe to assume that tx has failed.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
