### PR TITLE
fix: new authority is optional in SetAuthority

### DIFF
--- a/packages/solana/lib/src/programs/token_program/instruction.dart
+++ b/packages/solana/lib/src/programs/token_program/instruction.dart
@@ -191,6 +191,9 @@ class TokenInstruction extends Instruction {
       );
 
   /// Sets a new authority of a mint or account.
+  ///
+  /// The [newAuthority] is optional and can be used to specify a new
+  /// authority for this token.
   factory TokenInstruction.setAuthority({
     required Ed25519HDPublicKey mintOrAccount,
     required Ed25519HDPublicKey currentAuthority,

--- a/packages/solana/lib/src/programs/token_program/instruction.dart
+++ b/packages/solana/lib/src/programs/token_program/instruction.dart
@@ -214,11 +214,12 @@ class TokenInstruction extends Instruction {
         ],
         data: ByteArray.merge([
           TokenProgram.setAuthorityInstructionIndex,
-          ByteArray.u32(authorityType.value),
-          if (newAuthority != null)
-            newAuthority.toByteArray()
-          else
-            ByteArray(List<int>.filled(32, 0)),
+          ByteArray.u8(authorityType.value),
+          if (newAuthority != null) ...[
+            ByteArray.u8(1),
+            newAuthority.toByteArray(),
+          ] else
+            ByteArray.u8(0),
         ]),
       );
 

--- a/packages/solana/lib/src/programs/token_program/instruction.dart
+++ b/packages/solana/lib/src/programs/token_program/instruction.dart
@@ -195,7 +195,7 @@ class TokenInstruction extends Instruction {
     required Ed25519HDPublicKey mintOrAccount,
     required Ed25519HDPublicKey currentAuthority,
     required AuthorityType authorityType,
-    required Ed25519HDPublicKey newAuthority,
+    Ed25519HDPublicKey? newAuthority,
     List<Ed25519HDPublicKey> signers = const <Ed25519HDPublicKey>[],
   }) =>
       TokenInstruction._(
@@ -212,7 +212,10 @@ class TokenInstruction extends Instruction {
         data: ByteArray.merge([
           TokenProgram.setAuthorityInstructionIndex,
           ByteArray.u32(authorityType.value),
-          newAuthority.toByteArray(),
+          if (newAuthority != null)
+            newAuthority.toByteArray()
+          else
+            ByteArray(List<int>.filled(32, 0)),
         ]),
       );
 

--- a/packages/solana/test/programs/token_program/token_program_test.dart
+++ b/packages/solana/test/programs/token_program/token_program_test.dart
@@ -12,8 +12,7 @@ void main() {
   late final Ed25519HDKeyPair randomRecipient;
   late final Ed25519HDKeyPair newAuthority;
 
-  final rpcClient = RpcClient(devnetRpcUrl);
-  final subscriptionClient = SubscriptionClient.connect(devnetWebsocketUrl);
+  final client = createTestSolanaClient();
 
   setUpAll(() async {
     mint = await Ed25519HDKeyPair.random();
@@ -23,15 +22,15 @@ void main() {
     randomRecipient = await Ed25519HDKeyPair.random();
     newAuthority = await Ed25519HDKeyPair.random();
 
-    final signature = await rpcClient.requestAirdrop(
-      mintAuthority.address,
-      10 * lamportsPerSol,
+    await client.requestAirdrop(
+      address: mintAuthority.publicKey,
+      lamports: lamportsPerSol,
       commitment: Commitment.confirmed,
     );
-
-    await subscriptionClient.waitForSignatureStatus(
-      signature,
-      status: ConfirmationStatus.confirmed,
+    await client.requestAirdrop(
+      address: newAuthority.publicKey,
+      lamports: lamportsPerSol,
+      commitment: Commitment.confirmed,
     );
   });
 
@@ -39,19 +38,15 @@ void main() {
     Message message,
     List<Ed25519HDKeyPair> signers,
   ) async {
-    final signature = await rpcClient.signAndSendTransaction(
-      message,
-      signers,
+    await client.sendAndConfirmTransaction(
+      message: message,
+      signers: signers,
       commitment: Commitment.confirmed,
-    );
-    await subscriptionClient.waitForSignatureStatus(
-      signature,
-      status: ConfirmationStatus.confirmed,
     );
   }
 
   test('Initialize Mint', () async {
-    final rent = await rpcClient
+    final rent = await client.rpcClient
         .getMinimumBalanceForRentExemption(TokenProgram.neededMintAccountSpace);
     // Not throwing is sufficient as test, we need the mint to exist
     final instructions = TokenInstruction.createAccountAndInitializeMint(
@@ -69,7 +64,7 @@ void main() {
   });
 
   test('Create Account', () async {
-    final rent = await rpcClient
+    final rent = await client.rpcClient
         .getMinimumBalanceForRentExemption(TokenProgram.neededAccountSpace);
     final instructions = TokenInstruction.createAndInitializeAccount(
       mint: mint.publicKey,
@@ -252,22 +247,43 @@ void main() {
       newAuthority: newAuthority.publicKey,
     );
 
-    expect(
-      sendMessage(Message.only(instruction), [mintAuthority]),
-      completes,
+    await sendMessage(Message.only(instruction), [mintAuthority]);
+
+    final accountInfo = await client.rpcClient.getAccountInfo(
+      mint.publicKey.toBase58(),
+      commitment: Commitment.confirmed,
+      encoding: Encoding.jsonParsed,
     );
+
+    expect(accountInfo?.data, _hasMintAuthority(newAuthority.address));
   });
 
   test('Set Authority having no new authority', () async {
     final instruction = TokenInstruction.setAuthority(
       mintOrAccount: mint.publicKey,
       authorityType: AuthorityType.mintTokens,
-      currentAuthority: mintAuthority.publicKey,
+      currentAuthority: newAuthority.publicKey,
     );
 
-    expect(
-      sendMessage(Message.only(instruction), [mintAuthority]),
-      completes,
+    await sendMessage(Message.only(instruction), [newAuthority]);
+
+    final accountInfo = await client.rpcClient.getAccountInfo(
+      mint.publicKey.toBase58(),
+      commitment: Commitment.confirmed,
+      encoding: Encoding.jsonParsed,
     );
+
+    expect(accountInfo?.data, _hasMintAuthority(null));
   });
 }
+
+Matcher _hasMintAuthority(String? address) =>
+    isA<ParsedSplTokenProgramAccountData>().having(
+      (it) => it.parsed,
+      'parsed',
+      isA<MintAccountData>().having(
+        (it) => it.info.mintAuthority,
+        'mintAuthority',
+        address,
+      ),
+    );

--- a/packages/solana/test/programs/token_program/token_program_test.dart
+++ b/packages/solana/test/programs/token_program/token_program_test.dart
@@ -257,4 +257,17 @@ void main() {
       completes,
     );
   });
+
+  test('Set Authority having no new authority', () async {
+    final instruction = TokenInstruction.setAuthority(
+      mintOrAccount: mint.publicKey,
+      authorityType: AuthorityType.mintTokens,
+      currentAuthority: mintAuthority.publicKey,
+    );
+
+    expect(
+      sendMessage(Message.only(instruction), [mintAuthority]),
+      completes,
+    );
+  });
 }


### PR DESCRIPTION
## Changes
I have managed to pass the `newAuthority`  parameter as optional on the `TokenInstruction class`. I also added a test but failed to run the test since I am facing some network connection exceptions, saying "The remote computer refused the network connection."
<!-- Describe changes here. Attach screenshots/video if changes affect UI. -->
<!-- If PR is not ready for review yet, make it draft. -->
<!-- Add tests if it makes sense, especially if it's a bug fix. -->

## Related issues

Fixes #578 

## Checklist

- [ ] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [x] Tests added.
- [ ] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
