### PR TITLE
fix: add back button in app lock

### DIFF
--- a/packages/cryptoplease/lib/features/app_lock/src/presentation/app_lock_disable_screen.dart
+++ b/packages/cryptoplease/lib/features/app_lock/src/presentation/app_lock_disable_screen.dart
@@ -17,6 +17,9 @@ class AppLockDisableScreen extends StatelessWidget {
               context.read<AppLockSetupRouter>().onDisableFinished(),
         ),
         builder: (context, state) => DecoratedWindow(
+          backButton: BackButton(
+            onPressed: () => context.read<AppLockSetupRouter>().closeFlow(),
+          ),
           hasLogo: true,
           backgroundStyle: BackgroundStyle.dark,
           child: PinInputDisplayWidget(

--- a/packages/cryptoplease/lib/features/app_lock/src/presentation/app_lock_enable_screen.dart
+++ b/packages/cryptoplease/lib/features/app_lock/src/presentation/app_lock_enable_screen.dart
@@ -39,6 +39,9 @@ class _AppLockEnableScreenState extends State<AppLockEnableScreen> {
 
   @override
   Widget build(BuildContext context) => DecoratedWindow(
+        backButton: BackButton(
+          onPressed: () => context.read<AppLockSetupRouter>().closeFlow(),
+        ),
         hasLogo: true,
         backgroundStyle: BackgroundStyle.dark,
         child: PinInputDisplayWidget(


### PR DESCRIPTION
## Changes

- added back button for app lock pages

## Screenshot

![Simulator Screen Shot - iPhone 12 Pro - 2022-11-24 at 17 23 05](https://user-images.githubusercontent.com/28533130/203760355-462a3197-dce8-447b-9c91-b2387d7430a6.png)

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
