### PR TITLE
fix: add BuildContext to LogoutListener callback

### DIFF
--- a/packages/cryptoplease/lib/core/accounts/module.dart
+++ b/packages/cryptoplease/lib/core/accounts/module.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nested/nested.dart';
 
 import '../../di.dart';
+import '../callback.dart';
 import 'bl/accounts_bloc.dart';
 
 class AccountsModule extends SingleChildStatelessWidget {
@@ -24,7 +25,7 @@ class LogoutListener extends SingleChildStatelessWidget {
     required this.onLogout,
   }) : super(key: key, child: child);
 
-  final VoidCallback onLogout;
+  final Callback1<BuildContext> onLogout;
 
   @override
   Widget buildWithChild(BuildContext context, Widget? child) =>
@@ -32,7 +33,7 @@ class LogoutListener extends SingleChildStatelessWidget {
         listenWhen: (s1, s2) => s1.account != s2.account,
         listener: (context, state) {
           if (state.account == null) {
-            onLogout();
+            onLogout(context);
           }
         },
         child: child,

--- a/packages/cryptoplease/lib/core/callback.dart
+++ b/packages/cryptoplease/lib/core/callback.dart
@@ -1,0 +1,1 @@
+typedef Callback1<T> = void Function(T);

--- a/packages/cryptoplease/lib/features/activities/module.dart
+++ b/packages/cryptoplease/lib/features/activities/module.dart
@@ -27,7 +27,7 @@ class ActivitiesModule extends SingleChildStatelessWidget {
           ),
         ],
         child: LogoutListener(
-          onLogout: () =>
+          onLogout: (context) =>
               context.read<TxUpdaterBloc>().add(const TxUpdaterEvent.clear()),
           child: child,
         ),

--- a/packages/cryptoplease/lib/features/investments/module.dart
+++ b/packages/cryptoplease/lib/features/investments/module.dart
@@ -21,7 +21,7 @@ class InvestmentModule extends SingleChildStatelessWidget {
             create: (context) => sl<InvestmentSettingsRepository>(),
           ),
           LogoutListener(
-            onLogout: () =>
+            onLogout: (context) =>
                 context.read<InvestmentSettingsRepository>().clear(),
           ),
         ],

--- a/packages/cryptoplease/lib/features/payment_request/module.dart
+++ b/packages/cryptoplease/lib/features/payment_request/module.dart
@@ -16,7 +16,7 @@ class PaymentRequestModule extends SingleChildStatelessWidget {
 
   @override
   Widget buildWithChild(BuildContext context, Widget? child) => LogoutListener(
-        onLogout: () => sl<PaymentRequestRepository>().clear(),
+        onLogout: (_) => sl<PaymentRequestRepository>().clear(),
         child: child,
       );
 }


### PR DESCRIPTION
## Changes

`LogoutListener` callback needs `BuildContext` to retrieve dependencies.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
