### PR TITLE
fix: save reference in OuggoingDirectPayment

### DIFF
--- a/packages/cryptoplease/lib/features/outgoing_direct_payments/src/bl/bloc.dart
+++ b/packages/cryptoplease/lib/features/outgoing_direct_payments/src/bl/bloc.dart
@@ -74,6 +74,7 @@ class ODPBloc extends Bloc<_Event, _State> {
     final payment = OutgoingDirectPayment(
       id: event.id,
       receiver: event.receiver,
+      reference: event.reference,
       amount: event.amount,
       created: DateTime.now(),
       status: status,

--- a/packages/cryptoplease/pubspec.lock
+++ b/packages/cryptoplease/pubspec.lock
@@ -690,7 +690,7 @@ packages:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -886,10 +886,10 @@ packages:
   jupiter_aggregator:
     dependency: transitive
     description:
-      name: jupiter_aggregator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
+      path: "../cryptoplease_link/jupiter_aggregator"
+      relative: true
+    source: path
+    version: "0.0.3"
   logging:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Changes

Reference was not saved, so when the payment failed and retried, no information about reference was passed.

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
