### PR TITLE
fix: hide tokens based on fiat balance

### DIFF
--- a/packages/cryptoplease/lib/core/balances/bl/balances_state.dart
+++ b/packages/cryptoplease/lib/core/balances/bl/balances_state.dart
@@ -11,12 +11,6 @@ class BalancesState with _$BalancesState implements StateWithProcessingState {
 
   late final Set<Token> userTokens = {...balances.keys, Token.sol, Token.usdc};
 
-  late final Set<Token> userTokensWithPositiveBalance = {
-    ...balances.entries.where((e) => e.value.value != 0).map((e) => e.key),
-    Token.sol,
-    Token.usdc
-  };
-
   late final Set<Token> stableTokens =
       userTokens.where((t) => t.isStablecoin).toSet();
 

--- a/packages/cryptoplease/lib/features/investments/src/presentation/my_portfolio.dart
+++ b/packages/cryptoplease/lib/features/investments/src/presentation/my_portfolio.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/balances/bl/balances_bloc.dart';
+import '../../../../core/balances/presentation/watch_balance.dart';
 import '../data/repository.dart';
 import 'components/portfolio_widget.dart';
+
+const minimumUsdAmount = 0.01;
 
 class MyPortfolio extends StatelessWidget {
   const MyPortfolio({super.key});
@@ -17,11 +20,20 @@ class MyPortfolio extends StatelessWidget {
               .watch<InvestmentSettingsRepository>()
               .displayEmptyBalances;
 
+          final zeroAmountTokens = state.balances.keys
+              .where(
+                (token) =>
+                    (context.watchUserFiatBalance(token)?.value ?? 0) <
+                    minimumUsdAmount,
+              )
+              .toList();
+
           return PortfolioWidget(
             tokens: IList(
               displayEmptyBalances
                   ? state.userTokens
-                  : state.userTokensWithPositiveBalance,
+                  : state.userTokens
+                      .where((token) => !zeroAmountTokens.contains(token)),
             ),
           );
         },


### PR DESCRIPTION
## Changes

- Updated logic to hide tokens based on fiat amount instead of token amount

## Related issues

Fixes #534

## Checklist

- [ ] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
