### PR TITLE
fix: correct name of JSON field in getRecentPerformanceSamples result

### DIFF
--- a/packages/solana/lib/src/rpc/dto/perf_sample.dart
+++ b/packages/solana/lib/src/rpc/dto/perf_sample.dart
@@ -9,7 +9,7 @@ class PerfSample {
     required this.slot,
     required this.numTransactions,
     required this.numSlots,
-    required this.samplePeriodSec,
+    required this.samplePeriodSecs,
   });
 
   factory PerfSample.fromJson(Map<String, dynamic> json) =>
@@ -25,5 +25,5 @@ class PerfSample {
   final int numSlots;
 
   /// Number of seconds in a sample window.
-  final int samplePeriodSec;
+  final int samplePeriodSecs;
 }

--- a/packages/solana/lib/src/rpc/dto/perf_sample.g.dart
+++ b/packages/solana/lib/src/rpc/dto/perf_sample.g.dart
@@ -10,5 +10,5 @@ PerfSample _$PerfSampleFromJson(Map<String, dynamic> json) => PerfSample(
       slot: json['slot'] as int,
       numTransactions: json['numTransactions'] as int,
       numSlots: json['numSlots'] as int,
-      samplePeriodSec: json['samplePeriodSec'] as int,
+      samplePeriodSecs: json['samplePeriodSecs'] as int,
     );


### PR DESCRIPTION
## Changes

The Solana RPC call getRecentPerformanceSamples returns a result with a field named `samplePeriodSecs` while the lib tries to parse a field named `samplePeriodSec`. 

Solana doc with sample result: https://docs.solana.com/developing/clients/jsonrpc-api#getrecentperformancesamples


## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Self-review done.
