### PR TITLE
fix: swap tile copy in transaction list

### DIFF
--- a/packages/cryptoplease/lib/features/activities/src/widgets/swap_tile.dart
+++ b/packages/cryptoplease/lib/features/activities/src/widgets/swap_tile.dart
@@ -18,20 +18,22 @@ class SwapTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isBuyOperation = activity.data.seed.inputToken == Token.usdc;
-    final token = isBuyOperation
-        ? activity.data.seed.outputToken
-        : activity.data.seed.inputToken;
+    final seed = activity.data.seed;
+    final isBuyOperation = seed.inputToken == Token.usdc;
+    final isMatchToken = seed.amount.currency.token == seed.inputToken;
+    final token = isBuyOperation ? seed.outputToken : seed.inputToken;
+    final sign = isMatchToken ? '-' : '+';
 
     return ActivityTile(
       title: isBuyOperation
           ? context.l10n.boughtToken(token.name)
           : context.l10n.soldToken(token.name),
-      amount:
-          '-${activity.data.seed.amount.format(DeviceLocale.localeOf(context))}',
+      amount: '$sign${seed.amount.format(DeviceLocale.localeOf(context))}',
       subtitle: context.formatDate(activity.created),
       // TODO(rhbrunetto): improve icon
-      icon: Assets.icons.outgoing.svg(),
+      icon: isBuyOperation
+          ? Assets.icons.incoming.svg()
+          : Assets.icons.outgoing.svg(),
       onTap: () => context.router.navigate(ProcessSwapRoute(id: activity.id)),
     );
   }


### PR DESCRIPTION
## Changes

- Swap tile title and icon is displayed correctly based on the input type and operation.

<details><summary>Screenshot</summary>

![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-01-21 at 12 20 00](https://user-images.githubusercontent.com/19499575/213873632-83190754-db91-4592-9132-7d05847400e5.png)

</details>

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [x] Screenshots/video added.
- [ ] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
