### PR TITLE
fix!: ProgramAccount.rentEpoch is now BigInt

### DIFF
--- a/packages/solana/lib/src/programs/associated_token_account_program/solana_client_ext.dart
+++ b/packages/solana/lib/src/programs/associated_token_account_program/solana_client_ext.dart
@@ -78,7 +78,7 @@ extension SolanaClientAssociatedTokenAccontProgram on SolanaClient {
         owner: effectiveOwner.toBase58(),
         lamports: 0,
         executable: false,
-        rentEpoch: 0,
+        rentEpoch: BigInt.zero,
         data: null,
       ),
     );
@@ -113,7 +113,7 @@ extension SolanaClientAssociatedTokenAccontProgram on SolanaClient {
       owner: account.address,
       lamports: 0,
       executable: false,
-      rentEpoch: 0,
+      rentEpoch: BigInt.zero,
       data: null,
     );
   }

--- a/packages/solana/lib/src/rpc/dto/account.dart
+++ b/packages/solana/lib/src/rpc/dto/account.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:solana/src/rpc/dto/account_data/account_data.dart';
+import 'package:solana/src/rpc/helpers.dart';
 
 part 'account.g.dart';
 
@@ -34,5 +35,6 @@ class Account {
   final bool executable;
 
   /// The epoch at which this account will next owe rent, as u64
-  final int rentEpoch;
+  @JsonKey(fromJson: bigIntFromNum)
+  final BigInt rentEpoch;
 }

--- a/packages/solana/lib/src/rpc/dto/account.g.dart
+++ b/packages/solana/lib/src/rpc/dto/account.g.dart
@@ -11,5 +11,5 @@ Account _$AccountFromJson(Map<String, dynamic> json) => Account(
       owner: json['owner'] as String,
       data: json['data'] == null ? null : AccountData.fromJson(json['data']),
       executable: json['executable'] as bool,
-      rentEpoch: json['rentEpoch'] as int,
+      rentEpoch: bigIntFromNum(json['rentEpoch'] as num),
     );

--- a/packages/solana/lib/src/rpc/helpers.dart
+++ b/packages/solana/lib/src/rpc/helpers.dart
@@ -1,3 +1,5 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
 Map<K, V> fromJsonMap<K, V>(
   dynamic map,
   K Function(dynamic key) convertKey,
@@ -39,3 +41,6 @@ dynamic unwrapAndGetResult(dynamic raw) {
 
   return result['value'];
 }
+
+@internal
+BigInt bigIntFromNum(num value) => BigInt.from(value);


### PR DESCRIPTION
## Changes

Fixes parsing `rentEpoch` as it's represented by `u64`. See https://github.com/solana-labs/solana/pull/29528

## Checklist

- [x] PR is ready for review (if not, it should be a draft).
- [x] PR title follows [Conventional Commits][1] guidelines.
- [ ] Screenshots/video added.
- [x] Tests added.
- [x] Self-review done.

[1]: https://www.conventionalcommits.org/en/v1.0.0/
